### PR TITLE
Claude setup, Serial Explorer and Credit History Development

### DIFF
--- a/.claude/agent-memory/backend-engineer/MEMORY.md
+++ b/.claude/agent-memory/backend-engineer/MEMORY.md
@@ -1,0 +1,6 @@
+# backend-engineer memory
+
+Empty for now — this file accumulates stable patterns, architectural
+decisions, file paths, and recurring gotchas discovered while working in
+`backend/services/` across sessions. See the "Persistent Agent Memory" section
+of `.claude/agents/backend-engineer.md` for what belongs here.

--- a/.claude/agent-memory/e2e-qa-engineer/MEMORY.md
+++ b/.claude/agent-memory/e2e-qa-engineer/MEMORY.md
@@ -1,0 +1,7 @@
+# e2e-qa-engineer memory
+
+Empty for now — this file accumulates stable test-infra gotchas, factory
+patterns, and tooling notes discovered while working on the Playwright suite
+across sessions. See the "Persistent Agent Memory" section of
+`.claude/agents/e2e-qa-engineer.md` for what belongs here (and what belongs in
+`docs/testing/e2e-coverage.md` instead).

--- a/.claude/agent-memory/frontend-engineer/MEMORY.md
+++ b/.claude/agent-memory/frontend-engineer/MEMORY.md
@@ -1,0 +1,6 @@
+# frontend-engineer memory
+
+Empty for now — this file accumulates stable patterns, architectural
+decisions, file paths, and recurring gotchas discovered while working in
+`web/` across sessions. See the "Persistent Agent Memory" section of
+`.claude/agents/frontend-engineer.md` for what belongs here.

--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -1,0 +1,188 @@
+---
+name: backend-engineer
+description: >
+  Use for any work inside backend/services — NestJS controllers/services, TypeORM
+  entities and migrations, the ledger-db interface, CASL authorization, or the
+  RUN_MODULE-selected services (national-api, analytics-api, replicator,
+  async-operations-handler, data-importer). Examples: (1) "Add a `notes` field to
+  the Programme entity and expose it on the programme.controller.ts create/update
+  DTOs" -> generate a migration, update the entity/DTO/view-entity, wire the
+  controller. (2) "The replicator is dropping split-block events under load" ->
+  investigate backend/services/src/ledger-replicator/process.event.service.ts and
+  the pgsql-ledger vs qldb-ledger implementations. (3) "Add a new CASL rule so
+  Ministry Admins can read but not create Corresponding Adjustments" -> edit
+  libs/shared/src/casl/casl-ability.factory.ts and the relevant controller's
+  @Policy() guards.
+model: inherit
+color: blue
+---
+
+# Backend Engineer
+
+You own the NestJS backend under `backend/services/`. You are one of three
+subsystem subagents in this repo (siblings: `frontend-engineer` owns `web/`,
+`e2e-qa-engineer` owns `tests/e2e/`). Read `CLAUDE.md` at the repo root first —
+it has the full architecture writeup; don't duplicate it here, just apply it.
+
+## Scope & Boundaries
+
+- **Own**: everything under `backend/services/` (`src/`, `libs/shared/`,
+  `libs/core/`, `serverless.yml`, `Dockerfile`, `nest-cli.json`, `tsconfig*.json`,
+  `.env.example`, reference data CSVs/JSON at this level).
+- **Read but don't own**: root `docker-compose*.yml`, `deployment/*.yml`,
+  `.github/workflows/*` (touch only if a backend change requires it, and call
+  it out explicitly rather than silently editing deploy config).
+- **Never modify** `web/` or `tests/e2e/` unless the user explicitly asks you to
+  cross the boundary (e.g. a DTO change that requires a corresponding frontend
+  type update — in that case, say so and let the user route it, or make the
+  change and flag it clearly rather than assuming).
+- **Package manager**: yarn, always run from `backend/services/` (there is no
+  root `package.json` — do not run yarn/npm commands from the repo root).
+
+## Core Principles
+
+1. **Plan before acting** on anything non-trivial (new entity, new migration,
+   new module, cross-cutting refactor). Present the plan and wait for approval
+   before writing code.
+2. **Surgical changes.** This is a large, long-lived domain codebase — match
+   the existing style in the file/module you're touching rather than
+   introducing a new pattern.
+3. **Respect the architecture you're working inside, specifically:**
+   - **One NestJS app, many modules.** `src/main.ts` boots whichever modules are
+     listed in `RUN_MODULE` (comma-separated; default `national-api`). Don't
+     assume `national-api` is the only consumer of shared code you touch —
+     check whether `analytics-api`, `replicator`, `async-operations-handler`,
+     or `data-importer` also depend on it.
+   - **Dual-database ledger.** Writes go through the ledger (`libs/shared/src/ledger-db/ledger.db.interface.ts`,
+     implemented by `pgsql-ledger.service.ts` and `qldb-ledger.service.ts`,
+     selected by `LEDGER_TYPE`). Reads for lists/queries/analytics go through
+     the operational Postgres DB, populated *asynchronously* by
+     `ledger-replicator/process.event.service.ts`. If you change what a ledger
+     write emits, check whether the replicator and the corresponding
+     `view-entities/` need updating too — a mismatch here is a recurring class
+     of bug (see `docs/testing/e2e-coverage.md` for real examples of
+     replicator-lag-driven test flakiness).
+   - **Credit/serial-number semantics.** Partial transfers/retirements split a
+     credit block: the original owner keeps the low end of the serial range,
+     the counterparty gets a new block with the high end. This logic lives in
+     `libs/shared/src/credit-blocks-management/` and
+     `libs/shared/src/serial-number-management/` — don't reimplement it inline
+     in a controller/service.
+   - **CASL authorization is defined in exactly one backend place**:
+     `libs/shared/src/casl/casl-ability.factory.ts` (+ `policy.guard.ts` /
+     `@Policy()` decorator on controllers). If you add a new resource or
+     action, add it there, not as an ad-hoc `if (user.role === ...)` check in
+     a controller. Note this has a frontend mirror in `web/src/Casl/ability.ts`
+     that `frontend-engineer` owns — flag when your change requires it to be
+     updated too.
+   - **Pluggable external services** (`LOCATION_SERVICE`, `FILE_SERVICE`,
+     `ASYNC_OPERATIONS_TYPE`) are each behind an interface
+     (`location.interface.ts`, `filehandler.interface.ts`). Add new backends by
+     implementing the interface and registering it behind the env var, not by
+     branching inside callers.
+   - **Migrations are the current hot path** in this repo's recent history
+     (`fix migration issues`, `add necessary changes for migrations`,
+     `disable TypeORM synchronize in production` are all from the last dozen
+     commits). `DB_SYNCHRONIZE` must stay `false` outside local dev — never
+     suggest turning it on as a fix. Generate migrations from entity diffs with
+     `migration:generate`, don't hand-write schema changes unless the generator
+     can't express them.
+4. **Unit tests are non-negotiable for new/changed logic** — this repo's
+   CONTRIBUTING.md says new code should carry unit tests, and Jest is already
+   wired for both `src/` and `libs/` (see `roots` in `package.json`'s jest
+   config). Colocate `*.spec.ts` next to the code it tests, matching existing
+   files (e.g. `auth.service.spec.ts` next to `auth.service.ts`).
+5. **No committed ESLint config was found** in `backend/services/` despite the
+   `lint` script invoking `eslint`. If `yarn lint` errors out for a reason
+   unrelated to your change, say so rather than silently "fixing" it by adding
+   a new eslint config — that's a repo-level decision, flag it to the user.
+
+## Implementation Workflow
+
+1. **Understand & clarify** — read the relevant entity/service/controller and
+   its `.spec.ts`; check `libs/shared/src/dto/` for the contract shape; ask if
+   business-rule intent (not just code shape) is ambiguous.
+2. **Explore** — grep for other consumers of anything you're about to change
+   (a shared DTO, an enum, a ledger event shape) across `src/` and `libs/`.
+3. **Draft a plan** for anything beyond a one-file fix; get approval.
+4. **Implement incrementally** — entity/DTO changes, then service logic, then
+   controller wiring, then migration (generated last, from the final entity
+   state).
+5. **Test** — run the relevant `*.spec.ts` file(s), not just the full suite,
+   while iterating; run the full suite before calling it done.
+6. **Document** — update inline comments/README only where the existing file
+   already carries them; don't add new doc files unless asked.
+7. **Report back** — what changed, what you verified, what you didn't (e.g.
+   "migration generated but not run against a live DB — run
+   `yarn migration:run` after review").
+
+## Technical Reference
+
+- **Entry points**: `src/main.ts` (module bootstrap, `RUN_MODULE` switch),
+  `src/server.ts` (`buildNestApp` — Nest app factory, Swagger setup, global
+  pipes/filters), `src/data-source.ts` (TypeORM CLI data source for migrations).
+- **Ports**: national-api `:3000` (`/national`, Swagger at same path), stats
+  `:3100` (`/stats`). Local `sls offline` serves Swagger at
+  `http://localhost:3000/local/national`.
+- **Path aliases**: `@app/shared` -> `libs/shared/src`, `@app/core` ->
+  `libs/core/src` (see `tsconfig.json` `paths` and the jest `moduleNameMapper`).
+- **Key domain directories** under `libs/shared/src/`: `project-management/`,
+  `programme/`, `programme-ledger/`, `credit-blocks-management/`,
+  `credit-transactions-management/`, `corresponding-adjustment/`,
+  `cooperative-approach/`, `initial-report/`, `aef-report-management/`,
+  `itmo-account/`, `company/`, `user/`, `auth/`, `casl/`, `ledger-db/`,
+  `entities/`, `view-entities/`, `dto/`, `enum/`, `constants/`.
+- **Migrations**: `src/migrations/` (single baseline migration as of now —
+  `1780893992718-Baseline.ts`). Data source config: `src/data-source.ts`.
+- **Env reference**: `backend/services/.env.example` is the authoritative list
+  of variables (DB, JWT secrets, SMTP, `ASYNC_QUEUE_NAME`, `FILE_SERVICE`,
+  `LOCATION_SERVICE`, `LEDGER_TYPE`, host URLs). Root `.env.db.example` /
+  `.env.national.example` / `.env.replicator.example` are the per-container
+  slices used by `docker-compose.yml`.
+- **Reference/seed data at this level**: `countries.json`, `regions.csv`,
+  `cities.csv`, `districts.csv`, `provinces.csv`, `postalCodes.csv`,
+  `organisations.csv`, `users.csv` (the last two are mounted into the
+  `national` container and imported on every restart per `src/main.ts`).
+
+## Quality Gates
+
+Run from `backend/services/`, before considering work done:
+
+```
+yarn build                 # nest build — must succeed
+yarn lint                  # eslint --fix — run it, but see the no-config caveat above
+yarn test                  # full jest unit suite
+yarn test -- <file>.spec.ts   # scoped run while iterating
+```
+
+If you touched TypeORM entities: `yarn migration:generate <name>` and inspect
+the generated SQL before suggesting `migration:run` — never run migrations
+against a database you can't confirm is disposable/local without asking.
+
+## Communication Standards
+
+- Be explicit about trade-offs (e.g. "generated migration includes a column
+  drop your entity change didn't intend — probably from unrelated drift,
+  confirm before running").
+- Flag anything that touches the ledger-replicator contract, CASL rules, or a
+  shared DTO consumed by the frontend — these have cross-subsystem blast radius.
+- On ambiguous business/compliance rules (this codebase encodes specific UNFCCC
+  Article 6 decision paragraphs — e.g. Decision 2/CMA.3 ¶18, Draft -/CMA.5
+  ¶¶20-21), ask rather than guess; don't infer compliance behavior from
+  test-file comments alone without checking the service code they describe.
+
+## Persistent Agent Memory
+
+Memory file: `.claude/agent-memory/backend-engineer/MEMORY.md` (relative to
+repo root). This is project-scoped and committed — shared with the team.
+
+**Save**: stable architectural decisions you discover or make (e.g. "the
+replicator drops split-block events when a seed row's `NOW()` races the
+transfer service's `Date.now()` — see process.event.service.ts:339-344"),
+recurring gotchas (e.g. missing eslint config, `DB_SYNCHRONIZE` must stay
+false), file paths for things that were hard to find, and any convention you
+had to infer because it wasn't written down.
+
+**Don't save**: session-specific state (what you're currently mid-task on),
+unverified speculation, or anything that's just a restatement of what's already
+in `CLAUDE.md`.

--- a/.claude/agents/e2e-qa-engineer.md
+++ b/.claude/agents/e2e-qa-engineer.md
@@ -1,0 +1,179 @@
+---
+name: e2e-qa-engineer
+description: >
+  Use for any work on the Playwright suite under tests/e2e/article6, its
+  support fixtures/factories, playwright.config.ts, the testing docs under
+  docs/testing/, or scripts/seed-demo.sh. Examples: (1) "Add a test that a PD
+  cannot revoke another company's Cooperative Approach" -> add a case in
+  tests/e2e/article6/cooperative-approach.spec.ts using the existing apiPd /
+  apiDna fixtures, update docs/testing/e2e-coverage.md's coverage matrix.
+  (2) "Tests are flaking on queryTransfers visibility" -> check whether the
+  replicator container is up (this is a known, documented source of
+  replicator-lag flakiness) before assuming a real regression. (3) "Add a
+  factory to seed a Suspended Cooperative Approach directly via SQL" -> extend
+  tests/e2e/article6/support/factories.ts following the existing
+  seed*Direct naming and podman exec db psql pattern.
+model: inherit
+color: purple
+---
+
+# E2E / QA Engineer
+
+You own the Playwright end-to-end suite under `tests/e2e/`, `playwright.config.ts`
+at the repo root, the testing docs under `docs/testing/`, and `scripts/seed-demo.sh`.
+You are one of three subsystem subagents in this repo (siblings:
+`backend-engineer` owns `backend/services/`, `frontend-engineer` owns `web/`).
+Read `CLAUDE.md` at the repo root first — don't duplicate it here, just apply it.
+
+## Scope & Boundaries
+
+- **Own**: `tests/e2e/` (all specs + `support/`), `playwright.config.ts`,
+  `docs/testing/` (including the coverage audit and manual QA doc),
+  `scripts/seed-demo.sh`, `testing/api/` (legacy fixture CSVs).
+- **Never modify** `backend/services/` or `web/` source to make a test pass —
+  if a test reveals a real product bug, report it and hand off to
+  `backend-engineer`/`frontend-engineer` rather than patching product code
+  yourself, unless the user explicitly asks you to fix it directly.
+- **No package manager owns this directory** — there is no `package.json` at
+  the repo root or under `tests/`. Playwright is expected to be installed
+  ad hoc (`npm install -D @playwright/test` or similar) before running
+  anything here. Don't assume it's already installed; check first
+  (`npx playwright --version`) and say so if it isn't.
+
+## Core Principles
+
+1. **Plan before acting** on anything beyond adding a single test case to an
+   existing spec — new spec files, new factories, or changes to the seeding
+   strategy should be proposed first.
+2. **This suite requires a live stack.** Every test hits `http://localhost:3000`
+   (national API) and most also open `http://localhost:3030` (web). There is
+   no CI that runs the compose stack — this suite is dev-only. Before running
+   or debugging tests, confirm the stack is up
+   (`podman-compose up -d db national web replicator` per
+   `docs/testing/manual-qa-article6.md`) rather than assuming it is.
+3. **Seed helpers are podman-specific.** `factories.ts` functions named
+   `seed*Direct` (e.g. `seedCreditBlockDirect`, `seedProgrammeDirect`,
+   `seedAefActionDirect`) shell out to `podman exec db psql`. The container
+   name is hard-coded to `db` with an `E2E_DB_CONTAINER` override — if you're
+   on plain Docker instead of podman, these will fail silently or not at all;
+   flag this rather than debugging the test logic first.
+4. **Respect the replicator-lag reality.** The operational DB (what
+   `queryBalance`/`queryTransfers`/list endpoints read from) is populated
+   *asynchronously* from the ledger by the `replicator` container. A test that
+   writes via the ledger and immediately queries the operational DB can be
+   legitimately racy — that's why several factories read the ledger directly
+   via SQL instead of polling the replicated view, and why some specs poll
+   with a timeout instead of asserting immediately. Don't "fix" this pattern
+   by removing the poll/direct-read unless you're deliberately testing the
+   replicator itself.
+5. **The domestic transfer flow is synchronous, not two-phase** — there is no
+   `/approve` or `/reject` route; `/transfer` commits ownership immediately.
+   Don't write tests assuming a pending-approval step exists (this was a real,
+   previously-fixed misunderstanding — see `docs/testing/e2e-coverage.md`
+   gap #2).
+6. **Enum-cardinality tests are load-bearing by design.** Tests that assert an
+   exact enum value count (e.g. `NdcType` = 2, `CaMethod` = 3) are meant to
+   force a conscious update when a new value is added — don't treat a failure
+   there as automatically wrong; it may mean the coverage doc and the test
+   both need updating alongside the product enum change.
+7. **Keep `docs/testing/e2e-coverage.md` honest.** It's a living audit with
+   specific line-number citations (`file.spec.ts:NNN`). When you add, remove,
+   or fixme a test, update the relevant row/count rather than letting the doc
+   drift — it's the canonical source other engineers (and other subagents)
+   use to know what's actually covered.
+
+## Implementation Workflow
+
+1. **Understand & clarify** — read the target spec file and its neighbors in
+   `tests/e2e/article6/` to match existing structure (fixtures used, direct-SQL
+   vs HTTP seeding, assertion style).
+2. **Explore** — check `support/factories.ts` for an existing seed helper
+   before writing new setup code; check `support/fixtures.ts` for the right
+   role fixture (`dnaPage`/`pdPage`/`icPage`, `apiDna`/`apiPd`/`apiIc`/
+   `apiMinistry`/`apiDnaViewOnly`).
+3. **Draft a plan** for new spec files or factory changes; get approval.
+4. **Implement incrementally** — factory/seed helper first if needed, then the
+   test, running it in isolation before the full file.
+5. **Test the test** — run the new/changed spec directly, not the whole suite,
+   while iterating (workers default to concurrent — be aware shared-DB state
+   across specs can interfere; see the infra-gaps section of
+   `docs/testing/e2e-coverage.md`).
+6. **Document** — update `docs/testing/e2e-coverage.md`'s relevant table row
+   and the file-inventory totals if you added/removed/fixme'd tests.
+7. **Report back** — what you ran it against (stack state, container runtime),
+   pass/fail, and anything that looks like a real product bug vs. test
+   infrastructure flakiness.
+
+## Technical Reference
+
+- **Config**: `playwright.config.ts` (root) — `testMatch` is
+  `tests/e2e/article6/**/*.spec.ts` (plus two legacy root-level specs that are
+  no longer present); `baseURL` defaults to `http://localhost:3030`
+  (`E2E_BASE_URL` override); `headless: true`; single `chromium` project.
+- **Support layer** (`tests/e2e/article6/support/`):
+  - `auth.ts` — `BASE_URL`/`API_URL` (`E2E_BASE_URL`/`E2E_API_URL` overrides),
+    the `USERS` map (dnaAdmin/dnaViewOnly/pdAdmin/icAdmin/ministryAdmin/apiUser,
+    all password `123`), `login(page, userKey)` UI helper.
+  - `api-client.ts` — `createApiClient(userKey)` logs in via
+    `POST national/auth/login` and returns a token-bearing `get/post/put/delete`
+    client plus `expectOk()`.
+  - `fixtures.ts` — Playwright fixtures: `dnaPage`/`pdPage`/`icPage` (logged-in
+    browser pages), `apiDna`/`apiPd`/`apiIc`/`apiMinistry`/`apiDnaViewOnly`
+    (logged-in API clients).
+  - `factories.ts` — HTTP-driven factories (`createProgramme`,
+    `authorizeProgramme`, `issueCredits`, `initiateTransfer`,
+    `performRetireAction`, ...) and direct-SQL `seed*Direct` helpers for state
+    the HTTP API can't reach in one step.
+- **Seeded demo dataset**: produced by `scripts/seed-demo.sh` against
+  `http://localhost:3000/national`; reference table of what it produces
+  (CA-001/002/003, IR-001/002, projects 001-004, credit blocks) is in
+  `docs/testing/manual-qa-article6.md`.
+- **Wipe/reseed procedure**: `podman exec db psql` `TRUNCATE ... RESTART IDENTITY CASCADE`
+  commands documented at the top of `docs/testing/manual-qa-article6.md` —
+  IDs are server-generated counters that only restart from 1 after a full wipe.
+- **Spec inventory**: `cooperative-approach`, `initial-report`,
+  `programme-lifecycle`, `credit-issuance`, `credit-transfer`,
+  `itmo-lifecycle`, `retirement`, `corresponding-adjustment`, `aef-reporting`,
+  `omge-sop-deductions`, `cross-cutting` (the flagship full-lifecycle spec).
+
+## Quality Gates
+
+```
+npx playwright --version        # confirm it's installed before anything else
+podman-compose ps               # confirm db/national/web/replicator are up
+npx playwright test <spec-file>  # run the specific spec you touched
+npx playwright test tests/e2e/article6   # full suite before calling work done
+```
+
+A failing run is not automatically a regression — cross-reference
+`docs/testing/e2e-coverage.md`'s "Infrastructure gaps" section (replicator
+container state, podman vs Docker, shared-DB race surface) before reporting a
+product bug.
+
+## Communication Standards
+
+- Distinguish clearly between "test infrastructure issue" (stack not up,
+  wrong container runtime, replicator lag) and "real product regression" —
+  don't report one as the other.
+- When a test locks in *current* (possibly imperfect) behavior rather than
+  asserting a spec requirement, say so explicitly (the coverage doc already
+  does this in several places, e.g. Initial Report Submitted-state
+  immutability — follow that pattern).
+- Flag compliance-relevant edge cases you find uncovered rather than silently
+  skipping them — this suite exists to lock in Article 6 decision-paragraph
+  behavior, not just to keep CI green (there is no CI running it, by design).
+
+## Persistent Agent Memory
+
+Memory file: `.claude/agent-memory/e2e-qa-engineer/MEMORY.md` (relative to
+repo root). This is project-scoped and committed — shared with the team.
+
+**Save**: stable test-infra gotchas you discover (e.g. a new class of
+replicator-race flakiness and its workaround), factory patterns worth reusing,
+which container runtime/version was actually used successfully, and any
+product bug found via testing along with where it was reported/fixed.
+
+**Don't save**: session-specific state (which test you're mid-writing),
+unverified speculation, or content that duplicates `docs/testing/e2e-coverage.md`
+(update that doc directly instead — it's the canonical living record, this
+memory file is for things *not* worth putting there, like tooling gotchas).

--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -1,0 +1,156 @@
+---
+name: frontend-engineer
+description: >
+  Use for any work inside web/ — React components/pages, routing, CASL UI
+  gating, i18n, Vite/build config, or Ant Design forms. Examples: (1) "Add a
+  'Notes' field to the Programme create form" -> locate the form under
+  web/src/Pages/ProgrammeManagement, wire it to the DTO shape, add validation.
+  (2) "The sidebar shows Corresponding Adjustments to PD users, it shouldn't" ->
+  edit web/src/Components/Sider/layout.sider.tsx and cross-check
+  web/src/Casl/ability.ts. (3) "Add Spanish translations for the Initial Report
+  page" -> add the namespace under web/public/locales/ following the existing
+  i18next structure.
+model: inherit
+color: green
+---
+
+# Frontend Engineer
+
+You own the React/Vite frontend under `web/`. You are one of three subsystem
+subagents in this repo (siblings: `backend-engineer` owns `backend/services/`,
+`e2e-qa-engineer` owns `tests/e2e/`). Read `CLAUDE.md` at the repo root first —
+it has the full architecture writeup; don't duplicate it here, just apply it.
+
+## Scope & Boundaries
+
+- **Own**: everything under `web/` (`src/`, `public/`, `index.html`,
+  `vite.config.ts`, `eslint.config.js`, `tsconfig*.json`, `Dockerfile`,
+  `docker-entrypoint.sh`, `.env`, `.env-cmdrc`).
+- **Never modify** `backend/services/` or `tests/e2e/` unless the user
+  explicitly asks. If a UI change depends on a backend DTO/enum shape that
+  doesn't exist yet, say so and either stop or coordinate — don't invent
+  backend behavior by guessing a response shape.
+- **Package manager**: yarn, always run from `web/` (there is no root
+  `package.json` — do not run yarn/npm commands from the repo root).
+
+## Core Principles
+
+1. **Plan before acting** on anything beyond a small, contained fix (new page,
+   new context, cross-cutting config change). Present the plan and wait for
+   approval before writing code.
+2. **Surgical changes.** Match the existing style of the file/page you're
+   touching — this codebase is Ant Design (`antd` v4) + `styled-components` +
+   class-based CSS conventions inherited from an older React setup; don't
+   introduce a different UI kit or CSS approach in one corner of the app.
+3. **Respect the architecture you're working inside, specifically:**
+   - **`Pages/` mirrors backend module boundaries** (`ProgrammeManagement`,
+     `CreditPages`, `CooperativeApproaches`, `CorrespondingAdjustment`,
+     `InitialReport`, `Reports`, `UserManagement`, `CompanyManagement`,
+     `Dashboard`, ...). When adding a feature, find the page directory that
+     already matches its backend module rather than creating a new top-level
+     grouping.
+   - **`Config/` is the customization surface.** `Config/apiConfig.ts` holds
+     API base URLs and endpoint paths, `Config/uiRoutingConfig.ts` the route
+     table, `Config/colorConfigs.ts` theme colors. Country-specific deployments
+     override these — keep hardcoded strings out of components when they
+     belong here instead.
+   - **`Definitions/Enums` must stay parallel to the backend's `libs/shared/src/enum/`.**
+     If a dropdown's options don't match what the backend accepts, that's a
+     bug, not a frontend-only fix — flag the mismatch rather than silently
+     widening/narrowing the frontend enum.
+   - **CASL is duplicated, not shared, across the boundary.** `web/src/Casl/ability.ts`
+     mirrors `backend/services/libs/shared/src/casl/casl-ability.factory.ts`.
+     There is no code-sharing mechanism between them — if you change what a
+     role can do in the UI, the backend rule (owned by `backend-engineer`)
+     needs the same change independently, and vice versa. Never assume backend
+     enforcement means the UI gate is optional, or vice versa.
+   - **`Context/`** (`UserInformationContext`, `SettingsContext`,
+     `ConnectionContext`) carries auth/session, system settings, and
+     connectivity state. Prefer consuming these over prop-drilling or
+     re-fetching state a context already holds.
+   - **i18n**: English is complete; French/Spanish are in progress. New
+     user-facing strings should go through `i18next` (`public/locales/`), not
+     be hardcoded, even if only English exists today — see
+     `web/public/locales/i18n/README.md` for the namespace convention.
+4. **Tests**: there is no committed frontend unit-test runner in
+   `web/package.json` (no Jest/Vitest script) — UI correctness is currently
+   verified through the Playwright e2e suite owned by `e2e-qa-engineer`. Don't
+   invent a unit-test setup unasked; if a change is significant enough to need
+   automated coverage, say so and suggest looping in `e2e-qa-engineer` for an
+   e2e test rather than silently adding a new test framework.
+
+## Implementation Workflow
+
+1. **Understand & clarify** — find the existing page/component pattern closest
+   to what you're building; check how it consumes `Config/apiConfig.ts` and
+   `Definitions/Enums`; ask if UX intent is ambiguous.
+2. **Explore** — grep for other consumers of any shared component, enum, or
+   context you're about to change.
+3. **Draft a plan** for anything beyond a one-file fix; get approval.
+4. **Implement incrementally** — types/enums first if the backend contract is
+   involved, then the component, then routing/sidebar wiring if it's a new page.
+5. **Test** — `yarn dev` and exercise the flow manually (or ask
+   `e2e-qa-engineer` to add coverage); run `yarn lint` and `yarn build` before
+   calling it done.
+6. **Report back** — what changed, what you verified manually, and whether the
+   change has a CASL or enum counterpart on the backend that still needs doing.
+
+## Technical Reference
+
+- **Dev server**: `:3030` (`yarn dev`, Vite).
+- **Entry points**: `src/main.tsx`, `src/App.tsx` (top-level routing/providers).
+- **Structure**: `Config/` (api/routing/theme), `Definitions/` (`Enums`,
+  `Constants`, `Entities`, `InterfacesAndType`), `Context/` (session/settings/
+  connection), `Casl/` (`ability.ts`, `Can.ts`), `Components/` (shared UI —
+  `Sider/` for the role-gated sidebar, `AntComponents/`, `Layout/`, `Maps/`,
+  `PrivateRoute/`, etc.), `Pages/` (one dir per feature area), `locales/` +
+  `public/locales/` (i18next).
+- **Env/build args**: `web/.env` for dev; production builds take
+  `VITE_APP_BACKEND`, `VITE_APP_COUNTRY_NAME`, `VITE_APP_REGISTRY_NAME`,
+  `VITE_APP_MAP_TYPE`, `VITE_APP_MAPBOXGL_ACCESS_TOKEN`,
+  `VITE_APP_MAXIMUM_FILE_SIZE`, `REACT_APP_COUNTRY_FLAG_URL` as Docker build
+  args (see `.github/workflows/deployment-test.yml` and `docker-compose.yml`
+  for the full arg list) — note the mix of `VITE_APP_*` and `REACT_APP_*`
+  prefixes is inherited from a prior CRA setup and both are in live use, not a
+  typo to silently "fix".
+- **TypeScript**: strict mode is on for `src/` (`tsconfig.app.json` —
+  `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch` all
+  enabled). `yarn build` runs `tsc -b` before `vite build`, so type errors
+  block the build.
+
+## Quality Gates
+
+Run from `web/`, before considering work done:
+
+```
+yarn lint      # eslint .
+yarn build     # tsc -b && vite build — the only type-check path in this repo
+```
+
+There is no `yarn test` script — do not report "tests pass" for frontend work;
+report what you manually verified (`yarn dev` + the specific flow exercised),
+and flag if the change deserves a Playwright test.
+
+## Communication Standards
+
+- Be explicit about trade-offs, especially anything that changes an enum,
+  route, or CASL rule that has a backend counterpart.
+- Flag when a change should also be covered by an e2e test and hand that off
+  rather than assuming it's out of scope.
+- On ambiguous UX or role-permission questions, ask rather than guess —
+  this app has a real, documented role model (Root / DNA / Project
+  Developer / Independent Certifier, each Admin/Manager/ViewOnly) and getting
+  a gate wrong is a compliance issue, not just a UI bug.
+
+## Persistent Agent Memory
+
+Memory file: `.claude/agent-memory/frontend-engineer/MEMORY.md` (relative to
+repo root). This is project-scoped and committed — shared with the team.
+
+**Save**: stable UI conventions you discover (e.g. which components are the
+"canonical" pattern to copy for a new form), recurring gotchas (e.g. the
+`VITE_APP_*`/`REACT_APP_*` env prefix split), file paths that were hard to
+find, and any enum/CASL drift you found and had to reconcile with the backend.
+
+**Don't save**: session-specific state, unverified speculation, or anything
+already covered in `CLAUDE.md`.

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,37 @@
+---
+description: Stage task-relevant files and commit with a plain-imperative message matching this repo's recent commit style.
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Bash(git commit:*)
+---
+
+Create a git commit for the work just completed in this session.
+
+1. Run `git status` and `git diff` (staged and unstaged) to see everything
+   that changed, and `git log --oneline -15` to keep the message style
+   consistent with recent history.
+2. Stage **only the files relevant to the task just completed** — never
+   `git add -A` or `git add .` blindly. If unrelated changes are present
+   (e.g. stray local files, unrelated in-progress edits), leave them unstaged
+   and say so.
+3. Write a commit message in this repo's **plain imperative** style — no
+   Conventional Commits type/scope prefix. Match the tone of recent commits
+   like:
+   - `fix migration issues`
+   - `add missing values to example file`
+   - `make configuration values consistent`
+   - `disable TypeORM synchronize in production`
+
+   Lowercase first word, present-tense imperative, one line unless the change
+   genuinely needs a body paragraph explaining *why* (not *what* — the diff
+   already shows what).
+4. Do not commit anything under `.env`, `.env.*` (except the committed
+   `.env.*.example` files), or other files that look like they contain secrets
+   — warn instead of committing if one is staged.
+5. Create the commit with the message ending in:
+   ```
+   Co-Authored-By: Claude <noreply@anthropic.com>
+   ```
+6. Run `git status` after to confirm the commit succeeded and report what was
+   (and wasn't) included.
+
+Never use `--amend`, `--no-verify`, or force-push. If a pre-commit hook fails,
+fix the underlying issue and create a new commit rather than bypassing it.

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -26,11 +26,7 @@ Create a git commit for the work just completed in this session.
 4. Do not commit anything under `.env`, `.env.*` (except the committed
    `.env.*.example` files), or other files that look like they contain secrets
    — warn instead of committing if one is staged.
-5. Create the commit with the message ending in:
-   ```
-   Co-Authored-By: Claude <noreply@anthropic.com>
-   ```
-6. Run `git status` after to confirm the commit succeeded and report what was
+5. Run `git status` after to confirm the commit succeeded and report what was
    (and wasn't) included.
 
 Never use `--amend`, `--no-verify`, or force-push. If a pre-commit hook fails,

--- a/.claude/commands/lint-fix.md
+++ b/.claude/commands/lint-fix.md
@@ -1,0 +1,23 @@
+---
+description: Run ESLint --fix for backend and/or frontend.
+allowed-tools: Bash(cd backend/services && yarn lint), Bash(cd web && yarn lint)
+---
+
+Lint and auto-fix this repo. Run whichever side(s) are relevant to the change
+just made:
+
+- **Backend** (`backend/services/`): `yarn lint` runs
+  `eslint "{src,apps,test}/**/*.ts" --fix`. Note: no ESLint config file
+  (`.eslintrc*`) is committed under `backend/services/` — if this command
+  errors for a config-related reason rather than a real lint violation, say so
+  explicitly rather than papering over it or adding a new config file
+  unprompted.
+- **Frontend** (`web/`): `yarn lint` runs `eslint .` against
+  `web/eslint.config.js` (flat config — `@eslint/js` recommended +
+  `typescript-eslint` recommended + `eslint-plugin-react-hooks` +
+  `eslint-plugin-react-refresh`).
+
+After running, review what `--fix` changed (backend) before considering it
+done — auto-fixes can occasionally reformat more than intended in a large
+file. Report any violations that couldn't be auto-fixed, with the actual
+output.

--- a/.claude/commands/migration.md
+++ b/.claude/commands/migration.md
@@ -1,0 +1,43 @@
+---
+description: Generate, run, revert, or list TypeORM migrations for backend/services.
+allowed-tools: Bash(cd backend/services && yarn migration:*), Bash(cd backend/services && yarn typeorm:*), Read, Grep, Glob
+argument-hint: generate <name> | run | revert | show
+---
+
+Handle a TypeORM migration task in `backend/services` for argument: $ARGUMENTS
+
+Migrations use `src/data-source.ts` as the data source and live in
+`src/migrations/` (currently a single baseline migration). `DB_SYNCHRONIZE`
+must stay `false` outside local dev — never suggest flipping it on as a
+shortcut.
+
+Based on `$ARGUMENTS`:
+
+- **`generate <name>`**: first make sure the relevant TypeORM entities under
+  `backend/services/libs/shared/src/entities/` already reflect the intended
+  schema change (this command does not write entity code). Then run, from
+  `backend/services/`:
+  ```
+  yarn migration:generate src/migrations/<name>
+  ```
+  Read the generated file before reporting done — TypeORM's diff can include
+  unrelated drift (column drops/renames it inferred incorrectly). Flag
+  anything in the generated SQL that doesn't match the intended change; don't
+  silently accept it.
+
+- **`run`**: run `yarn migration:run` from `backend/services/`. Only do this
+  against a database you've confirmed is local/disposable — ask first if
+  that's not already established in this session.
+
+- **`revert`**: run `yarn migration:revert` from `backend/services/`. Same
+  local/disposable-DB caveat as `run`.
+
+- **`show`**: run `yarn migration:show` from `backend/services/` to list
+  applied vs. pending migrations — safe to run anytime.
+
+- **No argument / unclear**: ask which of the above is wanted rather than
+  guessing; running the wrong migration command against a shared database is
+  hard to undo.
+
+Report exactly which command ran, its output, and (for `generate`) a summary
+of what the generated migration actually does.

--- a/.claude/commands/typecheck.md
+++ b/.claude/commands/typecheck.md
@@ -1,0 +1,20 @@
+---
+description: Type-check the backend (nest build) and/or frontend (tsc -b) — the only type-check paths in this repo.
+allowed-tools: Bash(cd backend/services && yarn build), Bash(cd web && yarn build)
+---
+
+Type-check this repo. There is no standalone `tsc --noEmit` script in either
+app — the build commands are the type-check:
+
+- **Backend** (`backend/services/`): `yarn build` runs `nest build`, which
+  type-checks `src/` and both libs (`@app/shared`, `@app/core`) via their path
+  aliases.
+- **Frontend** (`web/`): `yarn build` runs `tsc -b && vite build` — `tsc -b`
+  is the actual type-check step (`web/src` is strict-mode: `noUnusedLocals`,
+  `noUnusedParameters`, `noFallthroughCasesInSwitch` all on), `vite build`
+  bundles.
+
+Run whichever side(s) are relevant to the change just made (both, if unsure or
+if the change touches a shared contract like a DTO consumed by the frontend).
+Report pass/fail per side with the actual error output on failure — don't
+summarize away type errors.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,70 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status)",
+      "Bash(git status:*)",
+      "Bash(git diff)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git show:*)",
+
+      "Bash(yarn install)",
+      "Bash(yarn install:*)",
+      "Bash(yarn build)",
+      "Bash(yarn lint)",
+      "Bash(yarn lint:*)",
+      "Bash(yarn test)",
+      "Bash(yarn test:*)",
+      "Bash(yarn test:cov)",
+      "Bash(yarn dev)",
+      "Bash(yarn migration:show)",
+      "Bash(yarn typeorm:*)",
+      "Bash(nest build)",
+
+      "Bash(cd backend/services && yarn install)",
+      "Bash(cd backend/services && yarn install:*)",
+      "Bash(cd backend/services && yarn build)",
+      "Bash(cd backend/services && yarn lint)",
+      "Bash(cd backend/services && yarn lint:*)",
+      "Bash(cd backend/services && yarn test)",
+      "Bash(cd backend/services && yarn test:*)",
+      "Bash(cd backend/services && yarn migration:show)",
+      "Bash(cd backend/services && yarn typeorm:*)",
+      "Bash(cd web && yarn install)",
+      "Bash(cd web && yarn install:*)",
+      "Bash(cd web && yarn build)",
+      "Bash(cd web && yarn lint)",
+      "Bash(cd web && yarn dev)",
+
+      "Bash(npx playwright --version)",
+      "Bash(npx playwright test:*)",
+
+      "Bash(docker-compose ps)",
+      "Bash(docker-compose ps:*)",
+      "Bash(docker-compose logs:*)",
+      "Bash(docker-compose up -d:*)",
+      "Bash(podman-compose ps)",
+      "Bash(podman-compose ps:*)",
+      "Bash(podman-compose logs:*)",
+      "Bash(podman-compose up -d:*)",
+      "Bash(podman exec db psql -U root -d carbondev -c *SELECT*)"
+    ],
+    "deny": [
+      "Read(**/.env)",
+      "Read(**/.env.local)",
+      "Read(**/.env.dev)",
+      "Read(**/.env.prod)",
+      "Read(**/.env.db)",
+      "Read(**/.env.national)",
+      "Read(**/.env.replicator)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Bash(cat **/.env)",
+      "Bash(cat **/.env.local)",
+      "Bash(cat **/.env.db)",
+      "Bash(cat **/.env.national)",
+      "Bash(cat **/.env.replicator)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+UNDP's National Carbon Credit Registry (v2.0) — an open-source toolkit for tracking, issuing, transferring, and retiring carbon credits under Article 6 of the Paris Agreement. Service-oriented architecture: a NestJS backend (`backend/services`) exposing multiple logical services from one codebase, and a React/Vite frontend (`web`).
+
+## Commands
+
+### Backend (`backend/services`)
+
+All commands run from `backend/services/`.
+
+```
+yarn install --frozen-lockfile   # sls:install does this via a cd; from inside the dir just use yarn install
+yarn build                       # nest build
+yarn start:dev                   # nest start --watch (single module — see RUN_MODULE below)
+yarn lint                        # eslint --fix
+yarn test                        # jest unit tests (*.spec.ts under src/ and libs/)
+yarn test -- path/to/file.spec.ts --testNamePattern "name"   # run a single test
+yarn test:cov                    # jest with coverage
+yarn test:e2e                    # jest e2e config (./test/jest-e2e.json) — NOT the Playwright suite, see below
+```
+
+TypeORM migrations (uses `src/data-source.ts`):
+```
+yarn migration:generate <path>   # generate from entity diffs
+yarn migration:create <path>     # blank migration
+yarn migration:run
+yarn migration:revert
+yarn migration:show
+```
+
+Local (non-container) run via Serverless offline:
+```
+yarn sls:install
+serverless invoke local --stage=local --function setup --data '{"rootEmail":"...","systemCountryCode":"..","name":"...","logoBase64":"..."}'
+sls offline --stage=local        # Swagger at http://localhost:3000/local/national
+```
+
+### Frontend (`web`)
+
+All commands run from `web/`.
+
+```
+yarn dev      # vite dev server on :3030
+yarn build    # tsc -b && vite build
+yarn lint     # eslint .
+yarn preview
+```
+
+### Full stack (containers)
+
+```
+docker-compose up -d --build     # or podman-compose (dev docs assume podman)
+```
+Brings up `db` (Postgres), `national` (national-api), `stats` (analytics-api), `replicator`, `web`. Frontend on `:3030`, national API on `:3000/national`, stats API on `:3100/stats`. Env is supplied via `.env.db`, `.env.national`, `.env.replicator` at repo root (see the `.env.*.example` files) plus `backend/services/.env.example` for the full backend variable reference. Emails are disabled by default (`IS_EMAIL_DISABLED=true`); generated passwords, including the root user's, are printed to the `national` container logs — grep for `Password (temporary)`.
+
+Demo data: `scripts/seed-demo.sh` (requires the stack up and `python3`/`curl`). Wipe/reseed procedure documented in `docs/testing/manual-qa-article6.md`.
+
+### E2E tests (Playwright)
+
+`playwright.config.ts` lives at the repo root and drives `tests/e2e/article6/**/*.spec.ts`. **There is no root `package.json`** — install `@playwright/test` ad hoc (`npm install -D @playwright/test` or equivalent) before running `npx playwright test`. Tests hit a live dev stack (`http://localhost:3000` national API, `http://localhost:3030` web) and several seed helpers in `tests/e2e/article6/support/factories.ts` shell out directly to `podman exec db psql` (override container name via `E2E_DB_CONTAINER`) — so the stack must be running under `podman-compose`, not plain Docker, for those helpers to work. See `docs/testing/e2e-coverage.md` for what's covered and known gaps, and `docs/testing/manual-qa-article6.md` for the manual QA walkthrough and seeded-data reference.
+
+## Architecture
+
+### One NestJS app, multiple logical services
+
+`backend/services/src/main.ts` boots one or more "modules" selected by the comma-separated `RUN_MODULE` env var (default `national-api`). Each is a full NestJS module mounted under its own HTTP path, or a one-shot handler:
+
+- `national-api` → `NationalAPIModule`, mounted at `/national`. Auth, users/companies, project & credit lifecycle. Controllers live flat under `src/national-api/*.controller.ts`.
+- `analytics-api` → `AnalyticsAPIModule`, mounted at `/stats`. Read-only statistics from the operational DB.
+- `replicator` → one-shot handler (`ledger-replicator/handler.ts`). Streams ledger events into the operational (Postgres) DB.
+- `async-operations-handler` → one-shot handler for queued/async work (email sending, etc.); selected via `ASYNC_OPERATIONS_TYPE=Database|Queue`.
+- `data-importer` → one-shot handler for external data imports (e.g. ITMO platform sync), controlled by `DATA_IMPORT_TYPES`.
+
+`docker-compose.yml` runs these as separate containers, each pointed at the same image with a different `RUN_MODULE`. `serverless.yml` packages the same modules as Lambda functions for AWS deployment instead.
+
+Shared code lives in two libs consumed via TS path aliases (`@app/shared`, `@app/core`):
+- `backend/services/libs/shared/src/` — almost all domain logic: one directory per bounded concern (`project-management`, `programme`, `credit-blocks-management`, `credit-transactions-management`, `corresponding-adjustment`, `cooperative-approach`, `aef-report-management`, `itmo-account`, `company`, `user`, `auth`, `casl`, etc.), plus cross-cutting `entities/`, `view-entities/`, `dto/`, `enum/`, `ledger-db/`.
+- `backend/services/libs/core/src/` — app configuration (`app-config/`).
+
+### Dual-database ledger architecture
+
+Two databases back every project/credit mutation:
+- **Ledger DB** (system of record) — implementations behind `libs/shared/src/ledger-db/ledger.db.interface.ts`: `pgsql-ledger.service.ts` (default) and `qldb-ledger.service.ts` (AWS QLDB, immutable/cryptographically verifiable). Selected via `LEDGER_TYPE=PGSQL|QLDB`. Writing a new ledger backend means implementing this interface.
+- **Operational DB** (Postgres, read side) — populated asynchronously by the `replicator` service from ledger events (`ledger-replicator/process.event.service.ts`), enriched with query-friendly data (e.g. geolocation via the location service). All `analytics-api` reads and most `national-api` list/query endpoints read from here, via `view-entities/`.
+
+Because reads lag writes through the replicator, an entity you just wrote via the ledger may not immediately appear in an operational-DB query — this shows up frequently in e2e tests, which sometimes poll or seed the operational DB directly to avoid replicator-timing flakiness.
+
+Credit identity: each project gets a project ID; each issuance batch gets a serial-number range within that project (format aligned to UNFCCC Decision 6/CMA.4 ¶17, e.g. `CA0004-VU-CH-356-1-3000-2023`). Transfers/retirements of a partial block split it — the original owner keeps the low end of the range, the counterparty gets a new block covering the high end. See `serial-number-management/` and `credit-blocks-management/`.
+
+### Pluggable external services
+
+Selected by env var, each behind its own interface so new backends can be added without touching callers:
+- `LOCATION_SERVICE=FILE|OPENSTREET|MAPBOX` → `libs/shared/src/location/location.interface.ts`
+- `FILE_SERVICE=LOCAL|S3` → `libs/shared/src/file-handler/filehandler.interface.ts`
+- `ASYNC_OPERATIONS_TYPE=Database|Queue`
+
+### Authorization
+
+CASL-based, defined once per side and kept in sync manually:
+- Backend: `libs/shared/src/casl/casl-ability.factory.ts` builds abilities per role (`role.enum.ts`: Root / DNA / Project Developer / Independent Certifier, each Admin/Manager/ViewOnly); `policy.guard.ts` + `@Policy()` decorator enforce it on controllers.
+- Frontend: `web/src/Casl/ability.ts` mirrors the same rules for UI gating (`Can` component), `web/src/Casl/Can.ts`.
+JWT auth (`libs/shared/src/auth/`) plus a separate API-key strategy for machine/MRV-system integration.
+
+### Frontend structure (`web/src`)
+
+- `Config/apiConfig.ts` — API base URLs and endpoint paths; `Config/uiRoutingConfig.ts` — route table; `Config/colorConfigs.ts` — theme colors (a primary branding customization point).
+- `Definitions/Enums` — controlled vocabularies (sectors, mitigation types, statuses, roles) driving dropdowns; kept parallel to backend `libs/shared/src/enum/`.
+- `Context/` — `UserInformationContext`, `SettingsContext`, `ConnectionContext` (auth/session, system settings, connectivity state).
+- `Pages/` — one directory per feature area (`ProgrammeManagement`, `CreditPages`, `CooperativeApproaches`, `CorrespondingAdjustment`, `InitialReport`, `Reports`, `UserManagement`, `CompanyManagement`, `Dashboard`, ...), generally mirroring the backend module boundaries.
+- `locales/` (+ `public/locales/`) — i18next translation namespaces; English shipped, French/Spanish in progress.
+
+### Customization
+
+This codebase is deployed per-country with local overrides layered on top rather than forked. The main touchpoints (see README §"Customization Framework and Extensibility" for the full rationale):
+
+| Area | Location |
+|---|---|
+| Frontend config / branding | `web/src/Config/`, `web/src/Styles/`, `web/public/` |
+| Frontend controlled vocab | `web/src/Definitions/Enums/` |
+| Backend enums/constants | `backend/services/libs/shared/src/enum/`, `.../constants/` |
+| DTOs / API contracts | `backend/services/libs/shared/src/dto/` |
+| Reference data | `backend/services/countries.json`, `regions.csv`, `organisations.csv`, `users.csv` |
+| Active module/backend selection | env vars: `RUN_MODULE`, `LEDGER_TYPE`, `LOCATION_SERVICE`, `FILE_SERVICE`, `ASYNC_OPERATIONS_TYPE` |
+| Localization | `web/public/locales/` |
+
+New optional functionality should be added as a new implementation of the relevant interface (ledger replicator, location, file-handler, data importer) registered/selected via env var, not as a hard-coded branch in existing services.
+
+### External integration: UNDP ITMO platform
+
+`data-importer` module syncs projects/credits with UNDP's ITMO Voluntary Bilateral Cooperation Platform (daily pull of authorized projects, push of issuances). Field mapping and sector-mapping tables are documented in the root `README.md` under "External Connectivity" — consult that before changing `data-importer/importers/`.

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-block-history-tree-examples.md
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-block-history-tree-examples.md
@@ -1,0 +1,220 @@
+# Credit block history tree — graph discovery & example
+
+Reference doc for the Explorer drill-down that reconstructs a credit block's
+full lineage — issuance → every split → every whole-block transfer/retirement
+— as a flat list of graph nodes. Implemented by
+`CreditTransactionsManagementService.getCreditBlockHistoryTree` (see
+`buildCreditBlockHistoryTree` / `groupCreditBlockLedgerVersions` /
+`findCreditBlockHistoryRoot` / `buildCreditBlockActionInfo` in
+`credit-transactions-management.service.ts`), exposed at
+`POST /national/creditTransactionsManagement/creditBlockHistory`.
+
+## Request
+
+```
+POST /national/creditTransactionsManagement/creditBlockHistory
+Authorization: Bearer <DNA-user JWT>
+Content-Type: application/json
+
+{ "blockId": "<any creditBlockId in the lineage>" }
+```
+
+DNA-only, same gate as `queryExplorer`. `blockId` can be **any** block id that
+ever existed in the lineage — the current leaf, an already-retired child, or
+the original root — since the root is found by *range containment* against
+the project's issuance batches, not by matching the id typed. All of them
+return the identical full tree.
+
+## Where the data comes from
+
+A block serial is `{prefix}-{projectId}-{blockStart}-{blockEnd}-{vintage}`,
+and `creditBlockId` is derived from the first 5 parts (`prefix...-{blockStart}`).
+Because of that, a block's **retained/low** portion keeps its id forever —
+splitting only narrows its range — while the **high** portion sheared off by
+a transfer/retirement always becomes a brand-new id.
+
+The operational Postgres DB only stores each block's *current* row, so once a
+block has been split more than once its earlier, wider ranges are gone. The
+append-only ledger keeps every version, so the reconstruction reads from
+there instead: `ProgrammeLedgerService.getCreditBlockLedgerHistory(projectRefId)`
+calls `LedgerDBInterface.fetchHistory({ projectRefId }, creditBlocksTable)`,
+returning every version of every block in the project, oldest first.
+
+## Response shape
+
+Every node is `{ range, children }`; the issuance root additionally carries
+`info` directly (its `children` is always empty). Every entry in `children`
+is `{ range, info }`, where `info` is a structured description of one action:
+
+```ts
+interface CreditBlockHistoryActionInfo {
+  companyId: number | null;
+  companyName: string | null;
+  timestamp: string;   // "YYYY-MM-DD HH:mm"
+  amount: number;       // size of that leaf's range (end - start + 1)
+  action: "ISSUE" | "RETAIN" | "TRANSFER" | "RETIRE";
+}
+```
+
+There is no free-text `note` field — everything the old `"{range} |
+Transferred to X"` / `"{range} | Self Retired"` strings encoded is now these
+structured fields, so the UI can render/filter/style without parsing text.
+
+## How graph discovery works, per scenario
+
+`groupCreditBlockLedgerVersions` buckets every ledger version by
+`creditBlockId`, preserving chronological order within each bucket.
+`findCreditBlockHistoryRoot` then picks the `ISSUE` version (no
+`previousOwnerCompanyId`) whose range contains the queried block's current
+range, in the same vintage — that's the tree's root regardless of how many
+splits deep the queried block is.
+
+From there, `buildCreditBlockHistoryTree` walks each group's own version
+list and classifies every **consecutive pair** `(before, after)`:
+
+| Scenario | Condition on `(before, after)` | Node produced |
+|---|---|---|
+| **Issuance** (root only, emitted once) | n/a — the group's very first version | `{ range, info: { action: "ISSUE", companyId, companyName, timestamp, amount }, children: [] }` |
+| **Split** (partial transfer/retirement) | same `range.start`, `after.range.end < before.range.end` | 2-child node: `{ range: <pre-split range>, children: [low, high] }`. `low` = the retained portion (`action: "RETAIN"`, `companyId`/`companyName` from `after.ownerCompanyId`), still in the *same* group. `high` = a brand-new block, looked up in a `(vintage, start, txTime)` index built from every other group's first version — the split's `txTime` and the new block's creation `txTime` are always written in the same ledger transaction, so this always resolves; its `info` (`TRANSFER` or `RETIRE`) comes from `buildCreditBlockActionInfo`. |
+| **Whole-block transition** (entire remaining balance moved in one action — full transfer, or full retirement) | same `range` (`start` *and* `end` unchanged), but `ownerCompanyId` changed | 1-child node: `{ range, children: [{ range, info }] }` via the same `buildCreditBlockActionInfo`. No new group is created (id/range unchanged), so there's nothing to recurse into. |
+| **No-op** (pending retire request, or one that was rejected/cancelled) | same `range`, **same** `ownerCompanyId` | *nothing* — silently skipped. A rejected/cancelled request also writes `txType = RETIRE`, so `ownerCompanyId` (not `txType`) is the signal that actually distinguishes a real retirement from a no-op. |
+
+A split and a whole-block transition can never both match the same pair: the
+retained/low side of a split never changes `ownerCompanyId` in that same
+version (only `creditAmount`/`serialNumber`/`txType` change), so the two
+conditions are mutually exclusive by construction.
+
+**`info` construction** (`buildCreditBlockActionInfo`, shared by a split's
+high child and a whole-block transition):
+- `ownerCompanyId === 0` → `action: "RETIRE"`. This is the authoritative
+  "this is a real retirement" signal, since a rejected/cancelled request
+  also sets `txType = RETIRE` without an owner change. `companyId`/
+  `companyName` deliberately identify the **retiring** company
+  (`previousOwnerCompanyId`) rather than the resulting owner — retired
+  credits have no owner (`0`), so showing that would make the node an
+  orphan with no company attached.
+- otherwise → `action: "TRANSFER"`, `companyId`/`companyName` from the new
+  `ownerCompanyId` (the receiver).
+- `amount` is always the leaf's own range size (`end - start + 1`), not the
+  parent block's full amount.
+
+**Traversal order** is depth-first and **ancestor-before-descendant**, not
+globally chronological across branches: a group's own chain of splits and
+transitions is listed in full (in that group's chronological order) before
+recursing into any branch a split spawned along the way. So a branch created
+early (e.g. by the *first* split) can end up appearing after later nodes on
+the "main" spine, once the spine's own history is exhausted.
+
+**Discriminating a node's kind in the response** — no explicit `type` field
+on the parent node; the UI infers it from `children.length`, or reads
+`children[0].info.action` directly:
+- `0` → issuance (root, `info` is on the node itself, not a child)
+- `1` → whole-block transition (`children[0].info.action` is `TRANSFER` or `RETIRE`)
+- `2` → split (`children[0].info.action` is always `RETAIN`)
+
+## Full worked example
+
+Project P, vintage 2024, serial prefix `CA0032-NG-XX-32`. Ids are named by
+which range they were first created with (`B0`..`B4`) — remember a
+retained/low block's id never changes even as its range narrows. Companies:
+Riverbend Power (`companyId 12`), Project Developer 1 (`45`), Buyer Y
+(`501`), Buyer W (`733`).
+
+| # | Time | Action | Ledger effect |
+|---|---|---|---|
+| 1 | 2024-01-05 09:12 | Issue 1000 to **Riverbend Power** | New block `B0` (`...-32-1`), range `1-1000`, `ISSUE` |
+| 2 | 2024-02-10 14:30 | Riverbend **partially transfers 400** to **Project Developer 1** | Split: `B0` narrows to `1-600` (retained). New `B1` (`...-32-601`), range `601-1000`, owner PD1, `TRANSFER` |
+| 3 | 2024-03-14 11:05 | Riverbend **partially retires 300** of `B0`'s remaining 600 | Split: `B0` narrows to `1-300` (retained). New `B2` (`...-32-301`), range `301-600`, owner `0`, `RETIRE` |
+| 4 | 2024-04-02 09:00 | Riverbend **whole-block transfers** the remaining 300 (`B0`) to **Buyer Y** | No split — same id, same range `1-300`, owner → Buyer Y, `TRANSFER` |
+| 5 | 2024-05-20 10:22 | Buyer Y **partially retires 150** of `B0`'s remaining 300 | Split: `B0` narrows to `1-150` (retained). New `B3` (`...-32-151`), range `151-300`, owner `0`, `RETIRE` |
+| 6 | 2024-06-01 / 06-02 | Buyer Y requests to retire 50 more; DNA **rejects** it | No split, no owner change — `RETIRE_REQ` then `RETIRE`(rejected) versions on `B0`, same range `1-150` |
+| 7 | 2024-07-09 08:41 | Buyer Y **whole-block retires** the remaining 150 (`B0`) | No split — same id, same range `1-150`, owner → `0`, `RETIRE` |
+| 8 | 2024-03-01 09:33 | PD1 **partially retires 200** of `B1`'s 400 | Split: `B1` narrows to `601-800` (retained). New `B4` (`...-32-801`), range `801-1000`, owner `0`, `RETIRE` |
+| 9 | 2024-03-22 12:47 | PD1 **whole-block transfers** the remaining 200 (`B1`) to **Buyer W** | No split — same id, same range `601-800`, owner → Buyer W |
+
+### Request
+
+```
+POST /national/creditTransactionsManagement/creditBlockHistory
+Authorization: Bearer <DNA-user JWT>
+Content-Type: application/json
+
+{ "blockId": "CA0032-NG-XX-32-151" }
+```
+
+(`B3`'s id — any of `B0`..`B4` returns the identical tree.)
+
+### Response
+
+```json
+{
+  "statusCode": 200,
+  "data": {
+    "history": [
+      {
+        "range": "1-1000",
+        "info": { "companyId": 12, "companyName": "Riverbend Power", "timestamp": "2024-01-05 09:12", "amount": 1000, "action": "ISSUE" },
+        "children": []
+      },
+      {
+        "range": "1-1000",
+        "children": [
+          { "range": "1-600", "info": { "companyId": 12, "companyName": "Riverbend Power", "timestamp": "2024-02-10 14:30", "amount": 600, "action": "RETAIN" } },
+          { "range": "601-1000", "info": { "companyId": 45, "companyName": "Project Developer 1", "timestamp": "2024-02-10 14:30", "amount": 400, "action": "TRANSFER" } }
+        ]
+      },
+      {
+        "range": "1-600",
+        "children": [
+          { "range": "1-300", "info": { "companyId": 12, "companyName": "Riverbend Power", "timestamp": "2024-03-14 11:05", "amount": 300, "action": "RETAIN" } },
+          { "range": "301-600", "info": { "companyId": 12, "companyName": "Riverbend Power", "timestamp": "2024-03-14 11:05", "amount": 300, "action": "RETIRE" } }
+        ]
+      },
+      {
+        "range": "1-300",
+        "children": [
+          { "range": "1-300", "info": { "companyId": 501, "companyName": "Buyer Y", "timestamp": "2024-04-02 09:00", "amount": 300, "action": "TRANSFER" } }
+        ]
+      },
+      {
+        "range": "1-300",
+        "children": [
+          { "range": "1-150", "info": { "companyId": 501, "companyName": "Buyer Y", "timestamp": "2024-05-20 10:22", "amount": 150, "action": "RETAIN" } },
+          { "range": "151-300", "info": { "companyId": 501, "companyName": "Buyer Y", "timestamp": "2024-05-20 10:22", "amount": 150, "action": "RETIRE" } }
+        ]
+      },
+      {
+        "range": "1-150",
+        "children": [
+          { "range": "1-150", "info": { "companyId": 501, "companyName": "Buyer Y", "timestamp": "2024-07-09 08:41", "amount": 150, "action": "RETIRE" } }
+        ]
+      },
+      {
+        "range": "601-1000",
+        "children": [
+          { "range": "601-800", "info": { "companyId": 45, "companyName": "Project Developer 1", "timestamp": "2024-03-01 09:33", "amount": 200, "action": "RETAIN" } },
+          { "range": "801-1000", "info": { "companyId": 45, "companyName": "Project Developer 1", "timestamp": "2024-03-01 09:33", "amount": 200, "action": "RETIRE" } }
+        ]
+      },
+      {
+        "range": "601-800",
+        "children": [
+          { "range": "601-800", "info": { "companyId": 733, "companyName": "Buyer W", "timestamp": "2024-03-22 12:47", "amount": 200, "action": "TRANSFER" } }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Reading the response against the timeline
+
+- **Node 1** — issuance (event 1). `children.length === 0`; `info.action === "ISSUE"`.
+- **Node 2** — split from event 2. `children.length === 2`; `low.info.action === "RETAIN"` (Riverbend, unchanged), `high.info.action === "TRANSFER"` to Project Developer 1.
+- **Node 3** — split from event 3. `high.info.action === "RETIRE"`, attributed to **Riverbend Power** — the company that performed the retirement, not a null/zero company.
+- **Node 4** — whole-block transition from event 4 (Riverbend → Buyer Y). `children.length === 1`, `action: "TRANSFER"`, `companyId: 501`. Sits between nodes 3 and 5, its correct chronological slot on the `B0` lineage.
+- **Node 5** — split from event 5. The `RETAIN` child now correctly attributes to **Buyer Y** — that's how event 4's ownership change surfaces, even though it got its own dedicated node (node 4) too.
+- **Node 6** — whole-block transition from event 7 (Buyer Y's final retirement). `action: "RETIRE"`, `companyId: 501` (Buyer Y, the retiring company) — `B0`'s terminal state.
+- **Event 6** (the rejected retire request) produces **no node** — `ownerCompanyId` never changed for that pair, so it's correctly invisible; it wasn't a completed transaction.
+- **Node 7** — split from event 8, on the `B1` branch. Appears *after* node 6 even though event 8 (`2024-03-01`) happened chronologically *before* events 4–7 — because the `B1` branch (spawned by node 2's split) is only visited once the `B0` spine's own chain is exhausted.
+- **Node 8** — whole-block transition from event 9 (PD1 → Buyer W), `action: "TRANSFER"`, `companyId: 733`, closing out the `B1` branch.

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.module.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.module.ts
@@ -10,6 +10,7 @@ import { CreditBlocksEntity } from "../entities/credit.blocks.entity";
 import { CreditBlockBalancesViewEntity } from "../view-entities/credit.block.balances.view.entity";
 import { CreditBlockTransfersViewEntity } from "../view-entities/credit.block.transfers.view.entity";
 import { CreditBlockRetirementsViewEntity } from "../view-entities/credit.block.retirements.view.entity";
+import { CreditBlockExplorerViewEntity } from "../view-entities/credit.block.explorer.view.entity";
 import { DocumentManagementModule } from "../document-management/document-management.module";
 import { AefReportManagementModule } from "../aef-report-management/aef-report-management.module";
 import { CooperativeApproach } from "../entities/cooperative.approach.entity";
@@ -25,6 +26,7 @@ import { CooperativeApproach } from "../entities/cooperative.approach.entity";
       CreditBlockBalancesViewEntity,
       CreditBlockTransfersViewEntity,
       CreditBlockRetirementsViewEntity,
+      CreditBlockExplorerViewEntity,
       CooperativeApproach,
     ]),
     DocumentManagementModule,

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.module.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.module.ts
@@ -14,12 +14,14 @@ import { CreditBlockExplorerViewEntity } from "../view-entities/credit.block.exp
 import { DocumentManagementModule } from "../document-management/document-management.module";
 import { AefReportManagementModule } from "../aef-report-management/aef-report-management.module";
 import { CooperativeApproach } from "../entities/cooperative.approach.entity";
+import { SerialNumberManagementModule } from "../serial-number-management/serial-number-management.module";
 
 @Module({
   imports: [
     UtilModule,
     CompanyModule,
     ProgrammeLedgerModule,
+    SerialNumberManagementModule,
     TypeOrmModule.forFeature([
       CreditTransactionsEntity,
       CreditBlocksEntity,

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
@@ -7,7 +7,7 @@ import { CompanyService } from "../company/company.service";
 import { ProgrammeLedgerService } from "../programme-ledger/programme-ledger.service";
 import { InjectRepository } from "@nestjs/typeorm";
 import { CreditBlocksEntity } from "../entities/credit.blocks.entity";
-import { EntityManager, Repository } from "typeorm";
+import { EntityManager, In, Repository } from "typeorm";
 import { TxType } from "../enum/txtype.enum";
 import { plainToClass } from "class-transformer";
 import { CreditTransactionsEntity } from "../entities/credit.transactions.entity";
@@ -37,6 +37,7 @@ import { CooperativeApproach } from "../entities/cooperative.approach.entity";
 import { CooperativeApproachStatus } from "../enum/cooperative.approach.status.enum";
 import { SerialNumberManagementService } from "../serial-number-management/serial-number-management.service";
 import { CreditBlockHistoryRequestDto } from "../dto/credit.block.history.request.dto";
+import { CreditBlockExplorerFirstTransferDto } from "../dto/credit.block.explorer.first.transfer.dto";
 import * as moment from "moment";
 
 /**
@@ -794,10 +795,128 @@ export class CreditTransactionsManagementService {
       .skip(query.size * query.page - query.size)
       .take(query.size)
       .getManyAndCount();
-    return new DataListResponseDto(
-      resp.length > 0 ? resp[0] : undefined,
-      resp.length > 1 ? resp[1] : undefined
+    const rows = resp.length > 0 ? resp[0] : [];
+    const total = resp.length > 1 ? resp[1] : undefined;
+    if (!rows || rows.length === 0) {
+      return new DataListResponseDto(rows, total);
+    }
+    const enrichedRows = await this.enrichExplorerRowsWithFirstTransfer(rows);
+    return new DataListResponseDto(enrichedRows, total);
+  }
+
+  /**
+   * Explorer enrichment: attach each row's first transfer (the transfer
+   * that first moved the block's credits out of the issuing
+   * organisation), computed in-memory over just the returned page rather
+   * than baked into the view SQL, to avoid recomputing lineage for the
+   * whole table on every query.
+   *
+   * isNotTransferred can't drive this on its own - it is flipped to
+   * false by retirement as well as transfer (see
+   * ProgrammeLedgerService.retirementRequestAction), so a block retired
+   * directly by its issuer would be misreported as transferred. The
+   * FIRST_TRANSFER CreditTransactionsEntity row (written in
+   * handleTransactionRecords, gated on the pre-update block still having
+   * isNotTransferred === true) is the unambiguous source: its
+   * presence/absence naturally yields null for both "still held by
+   * issuer" and "retired by issuer".
+   *
+   * Splits always shear credits off the top of a block's serial range
+   * (SerialNumberManagementService.splitCreditBlockSerialNumber), so
+   * every descendant block's range stays fully inside the sub-range that
+   * was first transferred - matching a row to its first transfer is
+   * therefore: same project + vintage, and the first-transfer's range
+   * contains the row's range.
+   */
+  private async enrichExplorerRowsWithFirstTransfer(
+    rows: CreditBlockExplorerViewEntity[]
+  ): Promise<Array<CreditBlockExplorerViewEntity & { firstTransfer: CreditBlockExplorerFirstTransferDto | null }>> {
+    const projectIds = Array.from(new Set(rows.map((r) => r.projectId)));
+    const firstTransferTxs = await this.creditTransactionsEntityRepository.find(
+      {
+        where: {
+          type: CreditTransactionTypesEnum.FIRST_TRANSFER,
+          status: CreditTransactionStatusEnum.COMPLETED,
+          projectRefId: In(projectIds),
+        },
+      }
     );
+
+    // Pre-parse each first-transfer's range/vintage once and group by
+    // project so matching a row doesn't reparse serials repeatedly.
+    interface ParsedFirstTransfer {
+      tx: CreditTransactionsEntity;
+      range: { start: number; end: number };
+      vintage: string;
+    }
+    const byProject = new Map<string, ParsedFirstTransfer[]>();
+    const companyIds = new Set<number>();
+    for (const tx of firstTransferTxs) {
+      let range: { start: number; end: number };
+      let vintage: string;
+      try {
+        range = this.serialNumberManagementService.getBlockRange(
+          tx.serialNumber
+        );
+        vintage = this.serialNumberManagementService.getVintage(
+          tx.serialNumber
+        );
+      } catch {
+        continue; // malformed/legacy serial - skip, never throw
+      }
+      if (
+        !Number.isFinite(range?.start) ||
+        !Number.isFinite(range?.end) ||
+        !vintage
+      ) {
+        continue;
+      }
+      const parsed: ParsedFirstTransfer = { tx, range, vintage };
+      const list = byProject.get(tx.projectRefId) ?? [];
+      list.push(parsed);
+      byProject.set(tx.projectRefId, list);
+      if (tx.senderId != null) companyIds.add(tx.senderId);
+      if (tx.recieverId != null) companyIds.add(tx.recieverId);
+    }
+
+    const companyNames = await this.resolveCompanyNames(companyIds);
+
+    return rows.map((row) => {
+      let firstTransfer: CreditBlockExplorerFirstTransferDto | null = null;
+      const candidates = byProject.get(row.projectId);
+      if (candidates && candidates.length > 0) {
+        try {
+          const rowRange = this.serialNumberManagementService.getBlockRange(
+            row.serialNumber
+          );
+          const rowVintage = this.serialNumberManagementService.getVintage(
+            row.serialNumber
+          );
+          const match = candidates.find(
+            (c) =>
+              c.vintage === rowVintage &&
+              c.range.start <= rowRange.start &&
+              c.range.end >= rowRange.end
+          );
+          if (match) {
+            firstTransfer = {
+              fromOrganizationId: match.tx.senderId,
+              fromOrganizationName:
+                companyNames.get(match.tx.senderId) ?? null,
+              toOrganizationId: match.tx.recieverId,
+              toOrganizationName:
+                companyNames.get(match.tx.recieverId) ?? null,
+              amount: match.tx.amount,
+              serialNumber: match.tx.serialNumber,
+              transferTime: match.tx.createTime,
+            };
+          }
+        } catch {
+          // malformed/legacy row serial - leave firstTransfer null
+        }
+      }
+      return { ...row, firstTransfer };
+    });
   }
 
   // ---------------------------------------------------------------------

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
@@ -24,6 +24,7 @@ import { CreditBlockBalancesViewEntity } from "../view-entities/credit.block.bal
 import { FilterEntry } from "../dto/filter.entry";
 import { CreditBlockTransfersViewEntity } from "../view-entities/credit.block.transfers.view.entity";
 import { CreditBlockRetirementsViewEntity } from "../view-entities/credit.block.retirements.view.entity";
+import { CreditBlockExplorerViewEntity } from "../view-entities/credit.block.explorer.view.entity";
 import { DocumentManagementService } from "../document-management/document-management.service";
 import { ProjectAuditLogType } from "../enum/project.audit.log.type.enum";
 import { DataResponseDto } from "../dto/data.response.dto";
@@ -53,6 +54,8 @@ export class CreditTransactionsManagementService {
     private creditBlockTransfersViewEntityRepository: Repository<CreditBlockTransfersViewEntity>,
     @InjectRepository(CreditBlockRetirementsViewEntity)
     private creditBlockRetirementsViewEntityRepository: Repository<CreditBlockRetirementsViewEntity>,
+    @InjectRepository(CreditBlockExplorerViewEntity)
+    private creditBlockExplorerViewEntityRepository: Repository<CreditBlockExplorerViewEntity>,
     private readonly aefReportManagementService: AefReportManagementService,
     // Draft -/CMA.5 paras 20-21 guard: refuse /transfer when the block's
     // linked cooperative approach has been revoked. Mirrors the
@@ -687,5 +690,372 @@ export class CreditTransactionsManagementService {
       resp.length > 0 ? resp[0] : undefined,
       resp.length > 1 ? resp[1] : undefined
     );
+  }
+
+  public async queryExplorer(
+    query: QueryDto,
+    abilityCondition: string,
+    user: User
+  ): Promise<DataListResponseDto> {
+    // Credits -> Explorer is a DNA-only, registry-wide browse of every
+    // credit block (including retired ones). Unlike queryCreditBalances /
+    // queryTransfers / queryRetirements, no other company role gets a
+    // scoped view here.
+    if (user.companyRole != CompanyRole.DESIGNATED_NATIONAL_AUTHORITY) {
+      throw new HttpException(
+        this.helperService.formatReqMessagesString(
+          "creditTransaction.unauthorized",
+          []
+        ),
+        HttpStatus.BAD_REQUEST
+      );
+    }
+    // The Explorer search box is sent as a single filterAnd entry keyed
+    // "serialColumns" whose operation is meaningless (generateWhereSQL
+    // would turn it into invalid SQL) - pull it out and translate it into
+    // its own predicate before the generic filter machinery runs.
+    const serialPredicate = this.extractSerialSearchPredicate(query);
+    const baseWhere = this.helperService.generateWhereSQL(
+      query,
+      abilityCondition
+    );
+    const qb =
+      this.creditBlockExplorerViewEntityRepository.createQueryBuilder(
+        "creditBlock"
+      );
+    if (baseWhere) {
+      qb.where(baseWhere);
+      if (serialPredicate) {
+        qb.andWhere(serialPredicate.sql, serialPredicate.params);
+      }
+    } else if (serialPredicate) {
+      qb.where(serialPredicate.sql, serialPredicate.params);
+    }
+    const resp = await qb
+      .orderBy(
+        query?.sort?.key && `"${query?.sort?.key}"`,
+        query?.sort?.order,
+        query?.sort?.nullFirst !== undefined
+          ? query?.sort?.nullFirst === true
+            ? "NULLS FIRST"
+            : "NULLS LAST"
+          : undefined
+      )
+      .skip(query.size * query.page - query.size)
+      .take(query.size)
+      .getManyAndCount();
+    return new DataListResponseDto(
+      resp.length > 0 ? resp[0] : undefined,
+      resp.length > 1 ? resp[1] : undefined
+    );
+  }
+
+  // ---------------------------------------------------------------------
+  // Explorer serial-number search
+  //
+  // A block serial is 7 "-"-separated parts (see
+  // serial-number-management.service.ts): creditId-country-
+  // firstTransferParty-projectId-rangeStart-rangeEnd-vintage, e.g.
+  // "CA0NNN-NG-XX-32-3001-4000-2023". The Explorer search box lets a user
+  // type any fragment of that - a full serial, a full/partial unit range,
+  // or a bare unit number - and expects it resolved against the numeric
+  // components (range/vintage/projectId) rather than a literal substring
+  // match, since the numbers shift position depending on how much of the
+  // serial was typed.
+  // ---------------------------------------------------------------------
+
+  /**
+   * Strip the "serialColumns" filterAnd entry (if present) out of the
+   * query in place - generateWhereSQL has no special handling for it and
+   * would otherwise emit malformed SQL - and translate its value into a
+   * standalone predicate for the caller to AND in separately.
+   */
+  private extractSerialSearchPredicate(
+    query: QueryDto
+  ): { sql: string; params: Record<string, any> } | null {
+    if (!query.filterAnd || query.filterAnd.length === 0) {
+      return null;
+    }
+    const serialEntries = query.filterAnd.filter(
+      (e) => e.key === "serialColumns"
+    );
+    query.filterAnd = query.filterAnd.filter(
+      (e) => e.key !== "serialColumns"
+    );
+    const searchValue = serialEntries
+      .map((e) => e.value)
+      .find((v) => v !== undefined && v !== null && String(v).trim() !== "");
+    if (searchValue === undefined) {
+      return null;
+    }
+    return this.buildSerialSearchPredicate(String(searchValue));
+  }
+
+  /**
+   * Translate one search-box value into a parameterized SQL predicate
+   * against the "creditBlock" alias. There are two interpretations,
+   * depending on the shape of the "-"-separated parts:
+   *
+   *  - "prefix" shape - one or more leading text parts immediately
+   *    followed by one or more numeric parts, and no text part after a
+   *    number (e.g. a serial typed from its start, "CA0NNN-NG-XX-32-3001",
+   *    including a full 7-part serial). Delegates to
+   *    `buildSerialPrefixPredicate`, which maps every part onto its fixed
+   *    serial section left-to-right (creditId, country,
+   *    firstTransferParty, projectId, rangeStart, rangeEnd, vintage)
+   *    instead of interpreting the numbers positionally from the right.
+   *  - anything else (numbers only, text only, or a text part following a
+   *    number) - the original "fragment" shape, handled inline below:
+   *     - non-numeric parts are ILIKE'd against the full serial string.
+   *     - numeric parts are interpreted positionally from the right:
+   *       1 number -> the unit the block's range must contain;
+   *       2 numbers -> the range's [lo, hi] boundaries, taken in the order
+   *         given (first number is lo, second is hi) - NOT reordered by
+   *         magnitude, so an inverted pair (lo > hi) is treated as an
+   *         invalid range and matches nothing;
+   *       3+ numbers -> the same positional range (the two before the
+   *         last) plus the last number ILIKE-matched against the vintage
+   *         component;
+   *       4+ numbers -> additionally the number before those three
+   *         ILIKE-matched against the projectId component;
+   *       any further leftover numbers are ILIKE-matched only against the
+   *       serial's "creditId-country-firstTransferParty" head, since
+   *       that's the only part of the serial without a defined numeric
+   *       slot.
+   * Range containment/overlap uses split_part() with a numeric guard so a
+   * legacy/malformed serial (non-numeric range parts) is excluded rather
+   * than throwing on cast.
+   */
+  private buildSerialSearchPredicate(
+    value: string
+  ): { sql: string; params: Record<string, any> } | null {
+    const parts = value
+      .trim()
+      .split("-")
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+    if (parts.length === 0) {
+      return null;
+    }
+    const numericParts: number[] = [];
+    const textParts: string[] = [];
+    for (const part of parts) {
+      if (/^\d+$/.test(part)) {
+        numericParts.push(Number(part));
+      } else {
+        textParts.push(part);
+      }
+    }
+
+    if (this.isSerialPrefixShape(parts)) {
+      return this.buildSerialPrefixPredicate(textParts, numericParts);
+    }
+
+    const conditions: string[] = [];
+    const params: Record<string, any> = {};
+
+    textParts.forEach((text, idx) => {
+      const paramKey = `serialTxt${idx}`;
+      params[paramKey] = `%${text}%`;
+      conditions.push(`creditBlock."serialNumber" ILIKE :${paramKey}`);
+    });
+
+    const n = numericParts.length;
+    if (n === 1) {
+      conditions.push(
+        this.serialRangeConditionSQL(numericParts[0], numericParts[0], params)
+      );
+    } else if (n === 2) {
+      conditions.push(
+        this.serialRangeConditionSQL(numericParts[0], numericParts[1], params)
+      );
+    } else if (n >= 3) {
+      conditions.push(
+        this.serialRangeConditionSQL(
+          numericParts[n - 3],
+          numericParts[n - 2],
+          params
+        )
+      );
+
+      params.serialVint = `%${numericParts[n - 1]}%`;
+      conditions.push(`${this.serialVintageExpr()} ILIKE :serialVint`);
+
+      const consumed = n >= 4 ? 4 : 3;
+      if (n >= 4) {
+        params.serialPid = `%${numericParts[n - 4]}%`;
+        conditions.push(`${this.serialProjectIdExpr()} ILIKE :serialPid`);
+      }
+      // Any numeric parts beyond the 4 known components (projectId,
+      // rangeStart, rangeEnd, vintage) don't map to a known numeric slot.
+      // The only remaining part of the serial is the
+      // creditId-country-firstTransferParty head, so match against that
+      // only - not the whole serial (which would also re-match the
+      // range/vintage/projectId digits already accounted for above).
+      numericParts.slice(0, n - consumed).forEach((num, idx) => {
+        const paramKey = `serialNum${idx}`;
+        params[paramKey] = `%${num}%`;
+        conditions.push(`${this.serialPrefixExpr()} ILIKE :${paramKey}`);
+      });
+    }
+
+    if (conditions.length === 0) {
+      return null;
+    }
+    return { sql: `(${conditions.join(" AND ")})`, params };
+  }
+
+  /**
+   * True when `parts` is shaped as one or more leading non-numeric parts
+   * immediately followed by one or more numeric parts, with no non-numeric
+   * part appearing after a numeric one - e.g. a serial (or any prefix of
+   * one) typed from its start, "CA0NNN-NG-XX-32-3001". This is the trigger
+   * for the left-anchored "prefix" interpretation in
+   * `buildSerialPrefixPredicate`; anything else (numbers only, text only,
+   * or a text part following a number) keeps the original right-anchored
+   * "fragment" interpretation.
+   */
+  private isSerialPrefixShape(parts: string[]): boolean {
+    let sawNumber = false;
+    let sawText = false;
+    for (const part of parts) {
+      if (/^\d+$/.test(part)) {
+        sawNumber = true;
+      } else {
+        sawText = true;
+        if (sawNumber) {
+          return false;
+        }
+      }
+    }
+    return sawText && sawNumber;
+  }
+
+  /**
+   * Build the predicate for the "prefix" shape (see `isSerialPrefixShape`):
+   * every part is mapped onto its fixed serial section, left-to-right -
+   * textParts fill creditId/country/firstTransferParty, numericParts fill
+   * projectId/rangeStart/rangeEnd/vintage:
+   *  - 1 number -> projectId only (exact match).
+   *  - 2 numbers -> projectId (exact) + the block's range must contain the
+   *    2nd number (a rangeStart with no rangeEnd typed yet).
+   *  - 3 numbers -> projectId (exact) + range overlap [2nd, 3rd] (no
+   *    vintage typed yet).
+   *  - 4 numbers -> projectId (exact) + range overlap [2nd, 3rd] + vintage
+   *    (exact).
+   *  - any further leftover numbers, or a 4th+ text part, don't map to a
+   *    known section, so they're ILIKE-matched against the whole serial
+   *    string instead of being dropped.
+   * projectId/vintage use exact string equality (not ILIKE) against their
+   * split_part() position - no numeric cast, so a legacy/malformed serial
+   * is excluded rather than throwing. Range overlap reuses
+   * `serialRangeConditionSQL`, which already guards non-numeric range
+   * parts and treats an inverted pair as unsatisfiable.
+   */
+  private buildSerialPrefixPredicate(
+    textParts: string[],
+    numericParts: number[]
+  ): { sql: string; params: Record<string, any> } | null {
+    const conditions: string[] = [];
+    const params: Record<string, any> = {};
+
+    const textExprs = [
+      this.serialCreditIdExpr(),
+      this.serialCountryExpr(),
+      this.serialFtpExpr(),
+    ];
+    textParts.forEach((text, idx) => {
+      const paramKey = `serialPfxTxt${idx}`;
+      params[paramKey] = `%${text}%`;
+      const expr = textExprs[idx] ?? `creditBlock."serialNumber"`;
+      conditions.push(`${expr} ILIKE :${paramKey}`);
+    });
+
+    const n = numericParts.length;
+    if (n >= 1) {
+      params.serialPfxPid = String(numericParts[0]);
+      conditions.push(`${this.serialProjectIdExpr()} = :serialPfxPid`);
+    }
+    if (n === 2) {
+      conditions.push(
+        this.serialRangeConditionSQL(numericParts[1], numericParts[1], params)
+      );
+    } else if (n >= 3) {
+      conditions.push(
+        this.serialRangeConditionSQL(
+          numericParts[1],
+          numericParts[2],
+          params
+        )
+      );
+    }
+    if (n >= 4) {
+      params.serialPfxVint = String(numericParts[3]);
+      conditions.push(`${this.serialVintageExpr()} = :serialPfxVint`);
+    }
+    // Leftover numbers beyond the 4 known slots (projectId, rangeStart,
+    // rangeEnd, vintage) don't map to a defined section.
+    numericParts.slice(4).forEach((num, idx) => {
+      const paramKey = `serialPfxNum${idx}`;
+      params[paramKey] = `%${num}%`;
+      conditions.push(`creditBlock."serialNumber" ILIKE :${paramKey}`);
+    });
+
+    if (conditions.length === 0) {
+      return null;
+    }
+    return { sql: `(${conditions.join(" AND ")})`, params };
+  }
+
+  /**
+   * Build the range predicate for a positional [lo, hi] pair, registering
+   * whatever params it needs into the shared `params` map. An inverted
+   * pair (lo > hi) is not a valid range - per business rule, it must
+   * match nothing - so it short-circuits to a literal FALSE instead of
+   * silently reordering into [hi, lo].
+   */
+  private serialRangeConditionSQL(
+    lo: number,
+    hi: number,
+    params: Record<string, any>
+  ): string {
+    if (lo > hi) {
+      return "FALSE";
+    }
+    params.serialLo = lo;
+    params.serialHi = hi;
+    return `(${this.serialRangeStartExpr()} <= :serialHi AND ${this.serialRangeEndExpr()} >= :serialLo)`;
+  }
+
+  private serialRangeStartExpr(): string {
+    return `CASE WHEN split_part(creditBlock."serialNumber", '-', 5) ~ '^[0-9]+$' THEN split_part(creditBlock."serialNumber", '-', 5)::int END`;
+  }
+
+  private serialRangeEndExpr(): string {
+    return `CASE WHEN split_part(creditBlock."serialNumber", '-', 6) ~ '^[0-9]+$' THEN split_part(creditBlock."serialNumber", '-', 6)::int END`;
+  }
+
+  private serialVintageExpr(): string {
+    return `split_part(creditBlock."serialNumber", '-', 7)`;
+  }
+
+  private serialProjectIdExpr(): string {
+    return `split_part(creditBlock."serialNumber", '-', 4)`;
+  }
+
+  private serialCreditIdExpr(): string {
+    return `split_part(creditBlock."serialNumber", '-', 1)`;
+  }
+
+  private serialCountryExpr(): string {
+    return `split_part(creditBlock."serialNumber", '-', 2)`;
+  }
+
+  private serialFtpExpr(): string {
+    return `split_part(creditBlock."serialNumber", '-', 3)`;
+  }
+
+  private serialPrefixExpr(): string {
+    return `(split_part(creditBlock."serialNumber", '-', 1) || '-' || split_part(creditBlock."serialNumber", '-', 2) || '-' || split_part(creditBlock."serialNumber", '-', 3))`;
   }
 }

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
@@ -35,6 +35,55 @@ import { Role } from "../casl/role.enum";
 import { CompanyState } from "../enum/company.state.enum";
 import { CooperativeApproach } from "../entities/cooperative.approach.entity";
 import { CooperativeApproachStatus } from "../enum/cooperative.approach.status.enum";
+import { SerialNumberManagementService } from "../serial-number-management/serial-number-management.service";
+import { CreditBlockHistoryRequestDto } from "../dto/credit.block.history.request.dto";
+import * as moment from "moment";
+
+/**
+ * One block's parsed ledger version, as seen by the credit-block
+ * history-tree reconstruction (see CreditTransactionsManagementService.
+ * getCreditBlockHistoryTree). `range` is derived from `serialNumber`
+ * since that's the only field carrying the live [start, end] through a
+ * split (itmoSerial is not reliably kept in sync on a retired split -
+ * see ProgrammeLedgerService.retirementRequestAction Case B).
+ */
+interface CreditBlockLedgerVersion {
+  creditBlockId: string;
+  range: { start: number; end: number };
+  txType: TxType;
+  txTime: number;
+  ownerCompanyId: number;
+  previousOwnerCompanyId?: number;
+  creditAmount: number;
+  vintage: string;
+}
+
+/**
+ * The structured description of a single action a credit-block history
+ * node/child represents (who did what, when, to how many credits). For
+ * RETIRE, companyId/companyName deliberately identify the company that
+ * *performed* the retirement (the block's previousOwnerCompanyId) rather
+ * than the resulting owner (always 0 - retired credits have no owner),
+ * so a retire action isn't shown as belonging to no one.
+ */
+interface CreditBlockHistoryActionInfo {
+  companyId: number | null;
+  companyName: string | null;
+  timestamp: string;
+  amount: number;
+  action: "ISSUE" | "RETAIN" | "TRANSFER" | "RETIRE";
+}
+
+interface CreditBlockHistoryNode {
+  range: string;
+  info?: CreditBlockHistoryActionInfo;
+  children: CreditBlockHistoryChildNode[];
+}
+
+interface CreditBlockHistoryChildNode {
+  range: string;
+  info: CreditBlockHistoryActionInfo;
+}
 
 @Injectable()
 export class CreditTransactionsManagementService {
@@ -61,7 +110,8 @@ export class CreditTransactionsManagementService {
     // linked cooperative approach has been revoked. Mirrors the
     // authorizeProgramme guard in programme.service.ts.
     @InjectRepository(CooperativeApproach)
-    private cooperativeApproachRepo: Repository<CooperativeApproach>
+    private cooperativeApproachRepo: Repository<CooperativeApproach>,
+    private readonly serialNumberManagementService: SerialNumberManagementService
   ) {}
 
   public async transferCredits(
@@ -748,6 +798,374 @@ export class CreditTransactionsManagementService {
       resp.length > 0 ? resp[0] : undefined,
       resp.length > 1 ? resp[1] : undefined
     );
+  }
+
+  // ---------------------------------------------------------------------
+  // Credit block history tree - the Explorer drill-down
+  //
+  // Reconstructs a credit block's full lineage - from initial issuance,
+  // through every partial transfer/retirement that split it, down to its
+  // current leaves - as a flat list of nodes the UI graph renders. See
+  // explorer-serial-search-examples.md's sibling doc-comment style: a
+  // block serial range shrinks every time part of it is transferred or
+  // retired, taking the amount off the TOP of the range
+  // (SerialNumberManagementService.splitCreditBlockSerialNumber). The
+  // retained/low portion keeps its original creditBlockId (its range
+  // start never changes); the transferred/retired high portion becomes a
+  // brand-new block with a new creditBlockId. The operational DB only
+  // keeps each block's *current* row, so intermediate ranges are gone by
+  // the time a block has been split more than once - the reconstruction
+  // therefore reads every version from the append-only ledger instead
+  // (ProgrammeLedgerService.getCreditBlockLedgerHistory).
+  // ---------------------------------------------------------------------
+
+  public async getCreditBlockHistoryTree(
+    creditBlockHistoryRequestDto: CreditBlockHistoryRequestDto,
+    user: User
+  ): Promise<DataResponseDto> {
+    // Same DNA-only gate as queryExplorer - this is a drill-down from it.
+    if (user.companyRole != CompanyRole.DESIGNATED_NATIONAL_AUTHORITY) {
+      throw new HttpException(
+        this.helperService.formatReqMessagesString(
+          "creditTransaction.unauthorized",
+          []
+        ),
+        HttpStatus.BAD_REQUEST
+      );
+    }
+
+    const queriedBlock = await this.creditBlocksEntityRepository.findOne({
+      where: { creditBlockId: creditBlockHistoryRequestDto.blockId },
+    });
+    if (!queriedBlock) {
+      throw new HttpException(
+        this.helperService.formatReqMessagesString(
+          "creditTransaction.creditBlockNotExists",
+          []
+        ),
+        HttpStatus.BAD_REQUEST
+      );
+    }
+
+    const ledgerVersions =
+      await this.programmeLedgerService.getCreditBlockLedgerHistory(
+        queriedBlock.projectRefId
+      );
+    const groups = this.groupCreditBlockLedgerVersions(ledgerVersions);
+
+    const queriedRange = this.serialNumberManagementService.getBlockRange(
+      queriedBlock.serialNumber
+    );
+    const rootVersions = this.findCreditBlockHistoryRoot(
+      groups,
+      queriedRange,
+      queriedBlock.vintage
+    );
+    if (!rootVersions) {
+      throw new HttpException(
+        this.helperService.formatReqMessagesString(
+          "creditTransaction.creditBlockNotExists",
+          []
+        ),
+        HttpStatus.BAD_REQUEST
+      );
+    }
+
+    const ownerCompanyIds = new Set<number>();
+    for (const versions of groups.values()) {
+      for (const v of versions) {
+        if (v.ownerCompanyId) {
+          ownerCompanyIds.add(v.ownerCompanyId);
+        }
+        // A RETIRE action attributes to the retiring company
+        // (previousOwnerCompanyId), not the resulting owner (always 0) -
+        // make sure its name is resolved too.
+        if (v.previousOwnerCompanyId) {
+          ownerCompanyIds.add(v.previousOwnerCompanyId);
+        }
+      }
+    }
+    const ownerNames = await this.resolveCompanyNames(ownerCompanyIds);
+
+    const history = this.buildCreditBlockHistoryTree(
+      groups,
+      rootVersions,
+      ownerNames
+    );
+    return new DataResponseDto(HttpStatus.OK, { history });
+  }
+
+  private groupCreditBlockLedgerVersions(
+    ledgerVersions: CreditBlocksEntity[]
+  ): Map<string, CreditBlockLedgerVersion[]> {
+    const groups = new Map<string, CreditBlockLedgerVersion[]>();
+    for (const version of ledgerVersions || []) {
+      const range = this.serialNumberManagementService.getBlockRange(
+        version.serialNumber
+      );
+      if (!Number.isFinite(range.start) || !Number.isFinite(range.end)) {
+        // Legacy/malformed serial - can't place it in the range-based
+        // tree, so it's excluded rather than throwing.
+        continue;
+      }
+      const parsed: CreditBlockLedgerVersion = {
+        creditBlockId: version.creditBlockId,
+        range,
+        txType: version.txType,
+        txTime: Number(version.txTime),
+        ownerCompanyId: Number(version.ownerCompanyId),
+        previousOwnerCompanyId:
+          version.previousOwnerCompanyId != null
+            ? Number(version.previousOwnerCompanyId)
+            : undefined,
+        creditAmount: version.creditAmount,
+        vintage: version.vintage,
+      };
+      if (!groups.has(parsed.creditBlockId)) {
+        groups.set(parsed.creditBlockId, []);
+      }
+      groups.get(parsed.creditBlockId).push(parsed);
+    }
+    return groups;
+  }
+
+  /**
+   * The root of the tree is the ISSUE version whose range contains the
+   * queried block's current range within the same vintage - regardless
+   * of how many splits deep the queried block is, since issuance batches
+   * within a project/vintage are contiguous and non-overlapping.
+   */
+  private findCreditBlockHistoryRoot(
+    groups: Map<string, CreditBlockLedgerVersion[]>,
+    queriedRange: { start: number; end: number },
+    vintage: string
+  ): CreditBlockLedgerVersion[] | undefined {
+    for (const versions of groups.values()) {
+      const first = versions[0];
+      if (
+        first.txType === TxType.ISSUE &&
+        first.previousOwnerCompanyId == null &&
+        first.vintage === vintage &&
+        first.range.start <= queriedRange.start &&
+        first.range.end >= queriedRange.end
+      ) {
+        return versions;
+      }
+    }
+    return undefined;
+  }
+
+  private async resolveCompanyNames(
+    companyIds: Set<number>
+  ): Promise<Map<number, string>> {
+    const names = new Map<number, string>();
+    await Promise.all(
+      Array.from(companyIds).map(async (id) => {
+        const company = await this.companyService.findByCompanyId(id);
+        if (company) {
+          names.set(id, company.name);
+        }
+      })
+    );
+    return names;
+  }
+
+  private formatCreditBlockHistoryTime(epochMs: number): string {
+    return moment(epochMs).format("YYYY-MM-DD HH:mm");
+  }
+
+  private formatCreditBlockRange(range: {
+    start: number;
+    end: number;
+  }): string {
+    return `${range.start}-${range.end}`;
+  }
+
+  /**
+   * The structured action info for a version that took ownership of
+   * `range` - shared between a split's "high" child (a brand-new block
+   * created by the split) and a whole-block transition (same block, no
+   * split, ownership just moved). `ownerCompanyId === 0` is the
+   * authoritative "this is a retirement" signal - unlike txType, which a
+   * rejected/cancelled retire request also sets to RETIRE without
+   * anything actually retiring (see ProgrammeLedgerService.
+   * retirementRequestAction's REJECT/CANCEL branch), so it can't be used
+   * alone to tell a real retirement apart from a rejected one. For a
+   * RETIRE, companyId/companyName identify the *retiring* company
+   * (previousOwnerCompanyId) rather than the resulting owner (always 0).
+   */
+  private buildCreditBlockActionInfo(
+    range: { start: number; end: number },
+    version: CreditBlockLedgerVersion,
+    ownerName: (companyId?: number) => string
+  ): CreditBlockHistoryActionInfo {
+    const amount = range.end - range.start + 1;
+    const timestamp = this.formatCreditBlockHistoryTime(version.txTime);
+    if (version.ownerCompanyId === 0) {
+      const retiringCompanyId = version.previousOwnerCompanyId ?? null;
+      return {
+        companyId: retiringCompanyId,
+        companyName: retiringCompanyId ? ownerName(retiringCompanyId) : null,
+        timestamp,
+        amount,
+        action: "RETIRE",
+      };
+    }
+    return {
+      companyId: version.ownerCompanyId,
+      companyName: ownerName(version.ownerCompanyId),
+      timestamp,
+      amount,
+      action: "TRANSFER",
+    };
+  }
+
+  /**
+   * Depth-first, ancestor-before-descendant reconstruction. For a given
+   * block's own version history, every consecutive pair of versions is
+   * one of:
+   *  - a split (same start, smaller end): the retained "low" portion
+   *    continues within the same creditBlockId group; the "high" portion
+   *    sheared off the top becomes a brand-new block, looked up by its
+   *    own group's first version matching (start, txTime, vintage).
+   *  - a whole-block transition (same range, ownerCompanyId changed): the
+   *    entire remaining balance was transferred or retired in one action,
+   *    so the block keeps its creditBlockId and range - no new group to
+   *    recurse into, just a single-child node recording the new owner.
+   *  - neither (e.g. a pending retire request, or one that was rejected/
+   *    cancelled - reservedCreditAmount/transactionRecords/txType may
+   *    change but ownerCompanyId doesn't): no node, silently skipped.
+   * Per the sample payload ordering, a group's own chain of splits and
+   * transitions is listed in full, in chronological order, before
+   * descending into any child branch created by a split along the way.
+   */
+  private buildCreditBlockHistoryTree(
+    groups: Map<string, CreditBlockLedgerVersion[]>,
+    rootVersions: CreditBlockLedgerVersion[],
+    ownerNames: Map<number, string>
+  ): CreditBlockHistoryNode[] {
+    const history: CreditBlockHistoryNode[] = [];
+
+    // Index every non-issuance group by the (vintage, start, txTime) of
+    // its first version, i.e. the split event that created it as a "high"
+    // child - so a shrink can look up the sibling it produced.
+    const childIndex = new Map<string, CreditBlockLedgerVersion[]>();
+    for (const versions of groups.values()) {
+      const first = versions[0];
+      if (first.previousOwnerCompanyId != null) {
+        childIndex.set(
+          `${first.vintage}#${first.range.start}#${first.txTime}`,
+          versions
+        );
+      }
+    }
+
+    const ownerName = (companyId?: number): string =>
+      companyId ? ownerNames.get(companyId) ?? `Company ${companyId}` : "";
+
+    const rootFirst = rootVersions[0];
+    history.push({
+      range: this.formatCreditBlockRange(rootFirst.range),
+      info: {
+        companyId: rootFirst.ownerCompanyId,
+        companyName: ownerName(rootFirst.ownerCompanyId),
+        timestamp: this.formatCreditBlockHistoryTime(rootFirst.txTime),
+        amount: rootFirst.creditAmount,
+        action: "ISSUE",
+      },
+      children: [],
+    });
+
+    const visit = (versions: CreditBlockLedgerVersion[]) => {
+      const pendingChildBranches: CreditBlockLedgerVersion[][] = [];
+      for (let i = 0; i + 1 < versions.length; i++) {
+        const before = versions[i];
+        const after = versions[i + 1];
+        const isSplit =
+          after.range.start === before.range.start &&
+          after.range.end < before.range.end;
+
+        if (isSplit) {
+          const lowRange = after.range;
+          const highRange = {
+            start: after.range.end + 1,
+            end: before.range.end,
+          };
+          const highVersions = childIndex.get(
+            `${after.vintage}#${highRange.start}#${after.txTime}`
+          );
+
+          const lowChild: CreditBlockHistoryChildNode = {
+            range: this.formatCreditBlockRange(lowRange),
+            info: {
+              companyId: after.ownerCompanyId,
+              companyName: ownerName(after.ownerCompanyId),
+              timestamp: this.formatCreditBlockHistoryTime(after.txTime),
+              amount: lowRange.end - lowRange.start + 1,
+              action: "RETAIN",
+            },
+          };
+          let highChild: CreditBlockHistoryChildNode;
+          if (highVersions) {
+            const highFirst = highVersions[0];
+            highChild = {
+              range: this.formatCreditBlockRange(highRange),
+              info: this.buildCreditBlockActionInfo(
+                highRange,
+                highFirst,
+                ownerName
+              ),
+            };
+            pendingChildBranches.push(highVersions);
+          } else {
+            // No matching child group in the ledger for this shrink - keep
+            // the tree structurally valid rather than throwing. `after`
+            // is the best available data for what happened here, since
+            // there's no separate highFirst version to draw from.
+            highChild = {
+              range: this.formatCreditBlockRange(highRange),
+              info: this.buildCreditBlockActionInfo(highRange, after, ownerName),
+            };
+          }
+
+          history.push({
+            range: this.formatCreditBlockRange(before.range),
+            children: [lowChild, highChild],
+          });
+          continue;
+        }
+
+        // Whole-block transition: the entire remaining balance was
+        // transferred or retired in one action, so the block kept its
+        // creditBlockId and range - no new group to recurse into, just a
+        // single-child node recording the new owner. Anything else with
+        // an unchanged range (a pending retire request, or one that was
+        // rejected/cancelled) leaves ownerCompanyId untouched and is
+        // silently skipped here.
+        const isWholeBlockTransition =
+          after.range.start === before.range.start &&
+          after.range.end === before.range.end &&
+          after.ownerCompanyId !== before.ownerCompanyId;
+        if (!isWholeBlockTransition) {
+          continue;
+        }
+
+        const transitionChild: CreditBlockHistoryChildNode = {
+          range: this.formatCreditBlockRange(after.range),
+          info: this.buildCreditBlockActionInfo(after.range, after, ownerName),
+        };
+        history.push({
+          range: this.formatCreditBlockRange(after.range),
+          children: [transitionChild],
+        });
+      }
+      for (const branch of pendingChildBranches) {
+        visit(branch);
+      }
+    };
+
+    visit(rootVersions);
+    return history;
   }
 
   // ---------------------------------------------------------------------

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
@@ -1394,7 +1394,7 @@ export class CreditTransactionsManagementService {
     textParts.forEach((text, idx) => {
       const paramKey = `serialTxt${idx}`;
       params[paramKey] = `%${text}%`;
-      conditions.push(`creditBlock."serialNumber" ILIKE :${paramKey}`);
+      conditions.push(`"creditBlock"."serialNumber" ILIKE :${paramKey}`);
     });
 
     const n = numericParts.length;
@@ -1504,7 +1504,7 @@ export class CreditTransactionsManagementService {
     textParts.forEach((text, idx) => {
       const paramKey = `serialPfxTxt${idx}`;
       params[paramKey] = `%${text}%`;
-      const expr = textExprs[idx] ?? `creditBlock."serialNumber"`;
+      const expr = textExprs[idx] ?? `"creditBlock"."serialNumber"`;
       conditions.push(`${expr} ILIKE :${paramKey}`);
     });
 
@@ -1535,7 +1535,7 @@ export class CreditTransactionsManagementService {
     numericParts.slice(4).forEach((num, idx) => {
       const paramKey = `serialPfxNum${idx}`;
       params[paramKey] = `%${num}%`;
-      conditions.push(`creditBlock."serialNumber" ILIKE :${paramKey}`);
+      conditions.push(`"creditBlock"."serialNumber" ILIKE :${paramKey}`);
     });
 
     if (conditions.length === 0) {
@@ -1565,34 +1565,34 @@ export class CreditTransactionsManagementService {
   }
 
   private serialRangeStartExpr(): string {
-    return `CASE WHEN split_part(creditBlock."serialNumber", '-', 5) ~ '^[0-9]+$' THEN split_part(creditBlock."serialNumber", '-', 5)::int END`;
+    return `CASE WHEN split_part("creditBlock"."serialNumber", '-', 5) ~ '^[0-9]+$' THEN split_part("creditBlock"."serialNumber", '-', 5)::int END`;
   }
 
   private serialRangeEndExpr(): string {
-    return `CASE WHEN split_part(creditBlock."serialNumber", '-', 6) ~ '^[0-9]+$' THEN split_part(creditBlock."serialNumber", '-', 6)::int END`;
+    return `CASE WHEN split_part("creditBlock"."serialNumber", '-', 6) ~ '^[0-9]+$' THEN split_part("creditBlock"."serialNumber", '-', 6)::int END`;
   }
 
   private serialVintageExpr(): string {
-    return `split_part(creditBlock."serialNumber", '-', 7)`;
+    return `split_part("creditBlock"."serialNumber", '-', 7)`;
   }
 
   private serialProjectIdExpr(): string {
-    return `split_part(creditBlock."serialNumber", '-', 4)`;
+    return `split_part("creditBlock"."serialNumber", '-', 4)`;
   }
 
   private serialCreditIdExpr(): string {
-    return `split_part(creditBlock."serialNumber", '-', 1)`;
+    return `split_part("creditBlock"."serialNumber", '-', 1)`;
   }
 
   private serialCountryExpr(): string {
-    return `split_part(creditBlock."serialNumber", '-', 2)`;
+    return `split_part("creditBlock"."serialNumber", '-', 2)`;
   }
 
   private serialFtpExpr(): string {
-    return `split_part(creditBlock."serialNumber", '-', 3)`;
+    return `split_part("creditBlock"."serialNumber", '-', 3)`;
   }
 
   private serialPrefixExpr(): string {
-    return `(split_part(creditBlock."serialNumber", '-', 1) || '-' || split_part(creditBlock."serialNumber", '-', 2) || '-' || split_part(creditBlock."serialNumber", '-', 3))`;
+    return `(split_part("creditBlock"."serialNumber", '-', 1) || '-' || split_part("creditBlock"."serialNumber", '-', 2) || '-' || split_part("creditBlock"."serialNumber", '-', 3))`;
   }
 }

--- a/backend/services/libs/shared/src/credit-transactions-management/explorer-serial-search-examples.md
+++ b/backend/services/libs/shared/src/credit-transactions-management/explorer-serial-search-examples.md
@@ -1,0 +1,92 @@
+# Explorer serial-number search — examples
+
+Reference examples for the `serialColumns` search predicate used by
+`CreditTransactionsManagementService.queryExplorer` (see
+`buildSerialSearchPredicate` / `extractSerialSearchPredicate` /
+`buildSerialPrefixPredicate` / `serialRangeConditionSQL` in
+`credit-transactions-management.service.ts`). Intended for business sign-off
+on the search behavior.
+
+A block serial is 7 `-`-separated parts:
+`creditId-country-firstTransferParty-projectId-rangeStart-rangeEnd-vintage`,
+e.g. `CA0NNN-NG-XX-32-3001-4000-2023`.
+
+`buildSerialSearchPredicate` picks one of two interpretations depending on
+the shape of the typed value:
+
+- **Prefix shape** — one or more leading text parts immediately followed by
+  one or more numeric parts (no text part after a number), e.g.
+  `CA0NNN-NG-XX-32-3001` or a full 7-part serial. The parts are mapped
+  **left-to-right onto the serial's fixed sections**: text →
+  creditId/country/firstTransferParty (per-position ILIKE), numbers →
+  projectId (exact) / rangeStart / rangeEnd (range overlap) / vintage
+  (exact). This is the pattern documented in this file's "Prefix search"
+  section below.
+- **Fragment shape** — anything else (numbers only, text only, or a text
+  part following a number). The original right-anchored rules apply: text
+  is ILIKE'd against the whole serial string, and numbers are interpreted
+  positionally **from the right** (last = vintage, the two before it =
+  range, etc). This is the pattern documented in "Search results" below.
+
+## Sample dataset (6 blocks)
+
+| Block | Serial | Project | Range | Vintage |
+|---|---|---|---|---|
+| **A** | `CA0NNN-NG-XX-32-3001-4000-2023` | 32 | 3001–4000 | 2023 |
+| **B** | `CA0NNN-NG-XX-30-3400-4200-2023` | 30 | 3400–4200 | 2023 |
+| **C** | `CA0NNN-NG-XX-45-1-1000-2022` | 45 | 1–1000 | 2022 |
+| **D** | `CA0NNN-NG-XX-32-1-3000-2021` | 32 | 1–3000 | 2021 |
+| **E** | `CA0NNN-NG-XX-99-3500-3500-2023` | 99 | 3500–3500 (unit) | 2023 |
+| **G** | `CA1NNN-NG-XX-32-3001-4000-2023` | 32 | 3001–4000 | 2023 — same as A, but prefix `CA1NNN` instead of `CA0NNN` |
+
+## Search results
+
+These all use terms with **no leading text before the first number**
+(numbers-only or text-only), so they take the **fragment shape** — numbers
+interpreted positionally from the right. Rows 1, 2 and 9 are full serials
+that *do* have a leading text prefix, so they actually take the **prefix
+shape** now (see below); they're kept in this table because their results
+are unchanged from the original right-anchored behavior — included here to
+show that continuity, with the "Why" column updated to describe the
+mechanism actually used.
+
+| # | Search term | Rule | Matches | Why |
+|---|---|---|---|---|
+| 1 | `CA0NNN-NG-XX-32-3001-4000-2023` | Full block serial (prefix shape) | **A** only | Per-position text `CA0NNN`/`NG`/`XX` + project `= 32` (exact) + range overlap `[3001,4000]` + vintage `= 2023` (exact) — G fails only on the creditId position (`CA1NNN` doesn't contain "CA0NNN"). |
+| 2 | `CA0NNN-NG-XX-32-3500-3500-2023` | Full unit serial (prefix shape) | **A** only | Range overlap collapses to `[3500,3500]`; A's range 3001–4000 contains it. G is excluded by the creditId position match, same as above. |
+| 3 | `3500` | Partial unit | **A, B, E, G** | Bare unit → any block whose range contains 3500, no other constraint. |
+| 4 | `9000` | Partial unit, negative | *(none)* | No block's range reaches 9000. |
+| 5 | `32-3500` | Two-number, ascending | **A, B, C, D, E, G** — all 6 | `lo=32 ≤ hi=3500` → valid range window; broadly overlaps every sample block. |
+| 6a | `2023-3500` | Two-number, ascending | **A, B, D, E, G** | `lo=2023 ≤ hi=3500` → valid; C's range (1–1000) doesn't reach 2023 so it's excluded. |
+| 6b | `3500-2023` | Two-number, **inverted** | **(none)** | `lo=3500 > hi=2023` → invalid range → predicate is unsatisfiable, matches nothing. |
+| 7 | `3500-3500-202` | Three-number | **A, B, E, G** | Range `[3500,3500]` (contains-3500 blocks) **AND** vintage `LIKE %202%` — all matching vintages (`2023`) contain "202". |
+| 8 | `3500-3500-9999` | Three-number, vintage mismatch | *(none)* | Same range as #7, but no vintage contains "9999". |
+| 9 | `CA0NNN-NG-XX-32-1-1000-2022` | Full serial, deliberately mismatched project (prefix shape) | *(none)* | Project `= 32` (exact) rules out **C** outright (C's real project is `45`). **D** has project `32` and its range `[1,3000]` overlaps `[1,1000]`, but D's vintage is `2021`, not `2022` (exact match) — excluded. |
+| 10 | `NG` | Text-only | **A, B, C, D, E, G** — all 6 | Plain substring match against the whole serial string. |
+| 11 | `1-32-3001-4000-2023` (5 numbers) | Leftover-number, fragment shape | **G only** | Rightmost 4 numbers parse as usual → project `%32%`, range `[3001,4000]`, vintage `%2023%` — both A and G satisfy that. The leftover `1` is ILIKE'd **only against the `creditId-country-firstTransferParty` head** (`CA0NNN-NG-XX` for A, `CA1NNN-NG-XX` for G). A's head has no "1" → excluded. G's head (`CA1NNN`) contains "1" → matches. |
+
+## Prefix search — typing a serial from the start
+
+New pattern: one or more leading text parts followed by one or more
+consecutive numeric parts (e.g. `CA0NNN-NG-XX-32-3001`) is read
+**left-anchored**, mapping parts onto the serial's fixed sections in order
+(creditId, country, firstTransferParty, projectId, rangeStart, rangeEnd,
+vintage) instead of positionally from the right. ProjectId and vintage use
+**exact** match on their position; a range is expressed with **overlap**
+semantics (a lone rangeStart number means "block range contains this
+unit").
+
+| # | Search term | Numbers map to | Matches | Why |
+|---|---|---|---|---|
+| P1 | `CA0NNN-NG-XX-32` | project only | **A, D** | Text `CA0NNN`/`NG`/`XX` (per-position) + project `= 32` (exact), no range/vintage constraint. Both A and D are project 32 with creditId `CA0NNN`. **B/C/E** excluded by project; **G** excluded by creditId (`CA1NNN`). |
+| P2 | `CA0NNN-NG-XX-32-3001` | project, rangeStart | **A** only | Project `= 32` + block range must **contain** unit `3001`. A's range 3001–4000 contains it; D's range 1–3000 stops just short (excluded). G excluded by creditId. |
+| P3 | `CA0NNN-NG-XX-32-3001-4000` | project, rangeStart, rangeEnd | **A** only | Project `= 32` + range **overlap** `[3001,4000]`, no vintage constraint yet. G excluded by creditId. |
+| P4 | `CA0NNN-NG-XX-32-1-3000-2021` | project, range, vintage | **D** only | Project `= 32` + range overlap `[1,3000]` + vintage `= 2021` (exact) — only D matches all four. |
+
+## Key rules worth explicit business sign-off
+
+- **Row 5 (`32-3500`) is intentionally broad.** Any two-number input with no leading text is *only* a range match — the numbers are taken purely as `[lo, hi]` boundaries in the order typed, with no positional meaning (not "project 32, unit 3500"). A wide window like this can match blocks from unrelated projects whose ranges happen to fall inside it.
+- **Row 6b confirms inverted ranges match nothing.** If the first number is greater than the second (`lo > hi`), the search is treated as invalid rather than being silently reordered.
+- **Row 11 confirms the 5th+ numeric token only matches the serial's leading `creditId-country-firstTransferParty` segment**, not the whole serial string — so it can't accidentally match by hiding inside the range/vintage/project digits already accounted for.
+- **A leading text part switches the numbers to left-anchored/section-positional matching** (project → range → vintage, in that order) instead of the right-anchored fragment rules, and switches project/vintage from substring to **exact** match. Text also becomes per-position (creditId/country/firstTransferParty) rather than a whole-serial substring match — this changes the *mechanism* for full-serial inputs like rows 1/2/9 above, though their results are unchanged on this sample dataset.
+- **Row P2 shows the "contains" rule for a lone rangeStart number** — `…-32-3001` does not require an exact rangeStart of 3001, it requires the block's range to contain unit 3001 (satisfies the "range overlap if necessary" requirement).

--- a/backend/services/libs/shared/src/dto/credit.block.explorer.first.transfer.dto.ts
+++ b/backend/services/libs/shared/src/dto/credit.block.explorer.first.transfer.dto.ts
@@ -1,0 +1,16 @@
+/**
+ * Explorer row enrichment: the transfer that first moved a credit block's
+ * credits out of the *issuing* organisation, at the root of the issued
+ * block's branch. Null when the issuing org still holds the block, or
+ * retired it directly without ever transferring it (see
+ * CreditTransactionsManagementService.queryExplorer).
+ */
+export class CreditBlockExplorerFirstTransferDto {
+  fromOrganizationId: number;
+  fromOrganizationName: string;
+  toOrganizationId: number;
+  toOrganizationName: string;
+  amount: number;
+  serialNumber: string;
+  transferTime: number;
+}

--- a/backend/services/libs/shared/src/dto/credit.block.history.request.dto.ts
+++ b/backend/services/libs/shared/src/dto/credit.block.history.request.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class CreditBlockHistoryRequestDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  blockId: string;
+}

--- a/backend/services/libs/shared/src/i18n/en/creditTransaction.json
+++ b/backend/services/libs/shared/src/i18n/en/creditTransaction.json
@@ -9,5 +9,6 @@
   "noRetireActionPermission": "You do not have permission to approve or reject credit retirement requests.",
   "creditRetirementReqAction": "Credit retirement request {}ed",
   "selfTransferRejected": "You cannot transfer credits to your own organisation. Pick a different recipient.",
-  "transferFromRevokedCa": "Credit block {} was issued under cooperative approach {}, which has since been Revoked. ITMO transfers from a Revoked CA are not permitted (Draft -/CMA.5 para 21)."
+  "transferFromRevokedCa": "Credit block {} was issued under cooperative approach {}, which has since been Revoked. ITMO transfers from a Revoked CA are not permitted (Draft -/CMA.5 para 21).",
+  "unauthorized": "You are not authorized to perform this action."
 }

--- a/backend/services/libs/shared/src/ledger-db/ledger.db.interface.ts
+++ b/backend/services/libs/shared/src/ledger-db/ledger.db.interface.ts
@@ -37,7 +37,10 @@ export abstract class LedgerDBInterface {
     tableName?: string
   ): Promise<dom.Value[]>;
 
-  abstract fetchHistory(where: Record<string, any>): Promise<dom.Value[]>;
+  abstract fetchHistory(
+    where: Record<string, any>,
+    tableName?: string
+  ): Promise<dom.Value[]>;
 
   abstract updateRecords(
     update: Record<string, any>,

--- a/backend/services/libs/shared/src/ledger-db/qldb-ledger.service.ts
+++ b/backend/services/libs/shared/src/ledger-db/qldb-ledger.service.ts
@@ -105,13 +105,18 @@ export class QLDBLedgerService implements LedgerDBInterface {
     )?.getResultList();
   }
 
-  public async fetchHistory(where: Record<string, any>): Promise<dom.Value[]> {
+  public async fetchHistory(
+    where: Record<string, any>,
+    tableName?: string
+  ): Promise<dom.Value[]> {
     const whereClause = Object.keys(where)
       .map((k) => `h.data.${k} = ?`)
       .join(" and ");
     const x = (
       await this.execute(
-        `SELECT * FROM history(${this.tableName}) as h WHERE ${whereClause}`,
+        `SELECT * FROM history(${
+          tableName ? tableName : this.tableName
+        }) as h WHERE ${whereClause}`,
         ...Object.values(where)
       )
     )?.getResultList();

--- a/backend/services/libs/shared/src/programme-ledger/programme-ledger.service.ts
+++ b/backend/services/libs/shared/src/programme-ledger/programme-ledger.service.ts
@@ -1349,6 +1349,32 @@ export class ProgrammeLedgerService {
     });
   }
 
+  /**
+   * All ledger versions of every credit block belonging to a project,
+   * chronological (oldest first). Unlike the operational DB's
+   * CreditBlocksEntity table - which only holds each block's *current*
+   * state, so a retained/low-range block's earlier, wider ranges are
+   * overwritten away as it's repeatedly split - the append-only ledger
+   * keeps every intermediate version. That full lineage is what a
+   * credit-block history/tree reconstruction (issuance -> splits ->
+   * transfers/retirements) needs to read from.
+   */
+  public async getCreditBlockLedgerHistory(
+    projectRefId: string
+  ): Promise<CreditBlocksEntity[]> {
+    return (
+      await this.ledger.fetchHistory(
+        { projectRefId: projectRefId },
+        this.ledger.creditBlocksTable
+      )
+    )?.map((domValue) => {
+      return plainToClass(
+        CreditBlocksEntity,
+        JSON.parse(JSON.stringify(domValue))
+      );
+    });
+  }
+
   public async getProgrammeHistoryByExternalId(
     externalId: string
   ): Promise<ProgrammeHistoryDto[]> {

--- a/backend/services/libs/shared/src/programme-ledger/programme-ledger.service.ts
+++ b/backend/services/libs/shared/src/programme-ledger/programme-ledger.service.ts
@@ -1368,10 +1368,11 @@ export class ProgrammeLedgerService {
         this.ledger.creditBlocksTable
       )
     )?.map((domValue) => {
-      return plainToClass(
-        CreditBlocksEntity,
-        JSON.parse(JSON.stringify(domValue))
-      );
+      // fetchHistory returns ledger revisions shaped as
+      // { data, meta, hash } - the actual CreditBlocks fields live under
+      // `data`, so unwrap before mapping to the flat entity.
+      const revision = JSON.parse(JSON.stringify(domValue));
+      return plainToClass(CreditBlocksEntity, revision.data ?? revision);
     });
   }
 

--- a/backend/services/libs/shared/src/serial-number-management/serial-number-management.service.ts
+++ b/backend/services/libs/shared/src/serial-number-management/serial-number-management.service.ts
@@ -95,6 +95,19 @@ export class SerialNumberManagementService {
     return Number(serailNumber.split(sep)[5]);
   }
 
+  /**
+   * Public [start, end] range accessor for callers outside this service
+   * (e.g. credit-block history/tree reconstruction) that need the same
+   * range parsing `splitCreditBlockSerialNumber` uses internally, without
+   * duplicating the separator/position logic.
+   */
+  public getBlockRange(serialNumber: string): { start: number; end: number } {
+    return {
+      start: this.getBlockStart(serialNumber),
+      end: this.getBlockEnd(serialNumber),
+    };
+  }
+
   public getVintage(serailNumber: string): string {
     const sep = this.configService.get("serialNumber.seperator");
     return serailNumber.split(sep)[6];

--- a/backend/services/libs/shared/src/view-entities/credit.block.explorer.view.entity.ts
+++ b/backend/services/libs/shared/src/view-entities/credit.block.explorer.view.entity.ts
@@ -1,0 +1,66 @@
+import { ViewColumn, ViewEntity } from "typeorm";
+
+// Credits -> Explorer tab: a registry-wide browse of every credit block,
+// including retired ones. Unlike CreditBlockBalancesViewEntity (which nets
+// out reservedCreditAmount and excludes ownerCompanyId = 0), the Explorer
+// needs the reserved amount as its own column and must surface retired
+// blocks, since retirement re-parents the block to ownerCompanyId = 0
+// rather than deleting it (see programme-ledger.service.ts). Columns are
+// scoped to exactly what the Explorer table renders; carry-over fields
+// (itmoSerial, vintage, accountType, etc.) belong to the future detail-modal
+// endpoint, not here.
+@ViewEntity({
+  expression: `
+    SELECT
+      cb."creditBlockId" AS "id",
+      cb."serialNumber" AS "serialNumber",
+      cb."ownerCompanyId" AS "organizationId",
+      o."name" AS "organizationName",
+      o."logo" AS "organizationLogo",
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      (cb."creditAmount" - cb."reservedCreditAmount") AS "balance",
+      cb."reservedCreditAmount" AS "reserved",
+      CASE
+        WHEN cb."ownerCompanyId" = 0 THEN 'Retired'
+        ELSE 'Assigned'
+      END AS "status",
+      cb."txTime" AS "updatedTime"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company o ON cb."ownerCompanyId" = o."companyId"`,
+})
+export class CreditBlockExplorerViewEntity {
+  @ViewColumn()
+  id: string;
+
+  @ViewColumn()
+  serialNumber: string;
+
+  @ViewColumn()
+  organizationId: number;
+
+  @ViewColumn()
+  organizationName: string;
+
+  @ViewColumn()
+  organizationLogo: string;
+
+  @ViewColumn()
+  projectId: string;
+
+  @ViewColumn()
+  projectName: string;
+
+  @ViewColumn()
+  balance: number;
+
+  @ViewColumn()
+  reserved: number;
+
+  @ViewColumn()
+  status: string;
+
+  @ViewColumn()
+  updatedTime: number;
+}

--- a/backend/services/src/migrations/1784708229614-migrations.ts
+++ b/backend/services/src/migrations/1784708229614-migrations.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Migrations1784708229614 implements MigrationInterface {
+    name = 'Migrations1784708229614'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE VIEW "credit_block_explorer_view_entity" AS 
+    SELECT
+      cb."creditBlockId" AS "id",
+      cb."serialNumber" AS "serialNumber",
+      cb."ownerCompanyId" AS "organizationId",
+      o."name" AS "organizationName",
+      o."logo" AS "organizationLogo",
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      (cb."creditAmount" - cb."reservedCreditAmount") AS "balance",
+      cb."reservedCreditAmount" AS "reserved",
+      CASE
+        WHEN cb."ownerCompanyId" = 0 THEN 'Retired'
+        ELSE 'Assigned'
+      END AS "status",
+      cb."txTime" AS "updatedTime"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company o ON cb."ownerCompanyId" = o."companyId"`);
+        await queryRunner.query(`INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`, ["public","VIEW","credit_block_explorer_view_entity","SELECT\n      cb.\"creditBlockId\" AS \"id\",\n      cb.\"serialNumber\" AS \"serialNumber\",\n      cb.\"ownerCompanyId\" AS \"organizationId\",\n      o.\"name\" AS \"organizationName\",\n      o.\"logo\" AS \"organizationLogo\",\n      cb.\"projectRefId\" AS \"projectId\",\n      p.\"title\" AS \"projectName\",\n      (cb.\"creditAmount\" - cb.\"reservedCreditAmount\") AS \"balance\",\n      cb.\"reservedCreditAmount\" AS \"reserved\",\n      CASE\n        WHEN cb.\"ownerCompanyId\" = 0 THEN 'Retired'\n        ELSE 'Assigned'\n      END AS \"status\",\n      cb.\"txTime\" AS \"updatedTime\"\n    FROM credit_blocks_entity cb\n    LEFT JOIN project_entity p ON cb.\"projectRefId\" = p.\"refId\"\n    LEFT JOIN company o ON cb.\"ownerCompanyId\" = o.\"companyId\""]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`, ["VIEW","credit_block_explorer_view_entity","public"]);
+        await queryRunner.query(`DROP VIEW "credit_block_explorer_view_entity"`);
+    }
+
+}

--- a/backend/services/src/national-api/credit.transactions.management.controller.ts
+++ b/backend/services/src/national-api/credit.transactions.management.controller.ts
@@ -7,6 +7,7 @@ import { CreditTransactionsManagementService } from "@app/shared/credit-transact
 import { CreditRetireActionDto } from "@app/shared/dto/credit.retire.action.dto";
 import { CreditRetireRequestDto } from "@app/shared/dto/credit.retire.request.dto";
 import { CreditTransferDto } from "@app/shared/dto/credit.transfer.dto";
+import { CreditBlockHistoryRequestDto } from "@app/shared/dto/credit.block.history.request.dto";
 import { QueryDto } from "@app/shared/dto/query.dto";
 import { ProjectEntity } from "@app/shared/entities/projects.entity";
 import { Body, Controller, Request, Post, UseGuards } from "@nestjs/common";
@@ -124,6 +125,24 @@ export class CreditTransactionsManagementController {
     return this.creditTransactionsManagementService.queryExplorer(
       queryDto,
       req.abilityCondition,
+      req.user
+    );
+  }
+
+  // Explorer drill-down: full lineage of one credit block (issuance ->
+  // splits -> transfers/retirements), reconstructed from the ledger.
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, PoliciesGuard)
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, ProjectEntity)
+  )
+  @Post("creditBlockHistory")
+  async creditBlockHistory(
+    @Body() creditBlockHistoryRequestDto: CreditBlockHistoryRequestDto,
+    @Request() req
+  ): Promise<any> {
+    return this.creditTransactionsManagementService.getCreditBlockHistoryTree(
+      creditBlockHistoryRequestDto,
       req.user
     );
   }

--- a/backend/services/src/national-api/credit.transactions.management.controller.ts
+++ b/backend/services/src/national-api/credit.transactions.management.controller.ts
@@ -110,4 +110,21 @@ export class CreditTransactionsManagementController {
       req.user
     );
   }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, PoliciesGuard)
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, ProjectEntity)
+  )
+  @Post("queryExplorer")
+  async queryExplorer(
+    @Body() queryDto: QueryDto,
+    @Request() req
+  ): Promise<any> {
+    return this.creditTransactionsManagementService.queryExplorer(
+      queryDto,
+      req.abilityCondition,
+      req.user
+    );
+  }
 }

--- a/backend/services/src/national-api/credit.transactions.management.controller.ts
+++ b/backend/services/src/national-api/credit.transactions.management.controller.ts
@@ -129,8 +129,6 @@ export class CreditTransactionsManagementController {
     );
   }
 
-  // Explorer drill-down: full lineage of one credit block (issuance ->
-  // splits -> transfers/retirements), reconstructed from the ledger.
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard, PoliciesGuard)
   @CheckPolicies((ability: AppAbility) =>


### PR DESCRIPTION
---
  Overview

  This PR bundles three pieces of work: the initial Claude Code setup for the repo, a new credit Explorer endpoint with serial-number search, and a credit block history endpoint that reconstructs the full lineage of a credit block. The two endpoints power the DNA-facing "Explorer" browse view and the drill-down history/tree view on top of it.

  Claude Code setup

  Adds the tooling scaffolding for working in this repo with Claude Code:

  - A project CLAUDE.md documenting the architecture (the one-NestJS-app / multiple-modules layout, the dual-database ledger model, pluggable external services, CASL
  auth, and the per-country customization framework) so anyone picking up the repo has the context up front.
  - Three scoped subagents — backend-engineer, frontend-engineer, and e2e-qa-engineer — each with its own memory file, so work stays in the right part of the codebase.
  - A few slash commands for the common chores here: commit, lint-fix, typecheck, and migration.
  - .claude/settings.json for shared project settings.

  This is all config/docs — no runtime behavior changes.

  Explorer endpoint (POST creditTransactionsManagement/queryExplorer)

  A DNA-only, registry-wide browse of every credit block — including retired ones — backed by a new credit_block_explorer_view_entity read view. Unlike the existing
  balance/transfer/retirement queries, this isn't scoped to a single company; it's the authority's view across the whole registry.

  The interesting part is the search box. It comes in as a single serialColumns filter and gets translated into a real SQL predicate against the serial number, handling
  the different ways someone might type a serial:

  - Prefix search — a serial typed from the start (e.g. CA0NNN-NG-XX-32-3001) maps each part onto its fixed serial section left-to-right (creditId, country,
  first-transfer party, projectId, range start/end, vintage).
  - Fragment search — loose numbers/text are matched more forgivingly: text parts are ILIKE'd against the serial, and numbers are read as range boundaries (one number =
  the unit a block's range must contain; two numbers = the [lo, hi] range).

  Range math uses split_part with a numeric guard so a legacy/malformed serial is quietly skipped rather than throwing on a bad cast. Results are also enriched with
  first-transfer information per block. Worked examples of the search behavior live in explorer-serial-search-examples.md.

  Credit block history endpoint (POST creditTransactionsManagement/creditBlockHistory)

  Given a blockId, this reconstructs and returns the full history tree of a credit block — issuance → splits → transfers → retirements. It reads every ledger revision
  for the block's project, groups them by block, finds the issuance root whose range contains the queried block, and walks the splits/transitions to build the tree.
  Company names are resolved along the way, and retirements are attributed to the retiring company rather than the (always-zero) resulting owner. Example tree shapes are
  documented in credit-block-history-tree-examples.md.

  ---

[Jira Task](https://xeptagon.atlassian.net/browse/UNCR-451)