### PR TITLE
add reusable responsive filter bar and credit balance filters

### DIFF
--- a/web/src/Components/Common/FilterBar/FilterBar.scss
+++ b/web/src/Components/Common/FilterBar/FilterBar.scss
@@ -1,0 +1,162 @@
+.filter-bar {
+  width: 100%;
+  padding: 16px;
+  border: none;
+  border-radius: 8px;
+  margin-bottom: 16px;
+
+  &--light { background: #fff; color: #3a3541; }
+  &--dark {
+    background: #232e3d;
+    color: #fff;
+
+    .filter-bar__control-label, .filter-bar__applied-label { color: #fff; }
+    .filter-bar__applied { border-color: #465466; }
+    .ant-tag { color: #fff; background: #344256; border-color: #5b6b80; }
+  }
+
+  &--disabled { opacity: 0.72; }
+
+  &__toolbar, &__radio-group, &__controls, &__control, &__applied, &__chips {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  &__toolbar { justify-content: space-between; flex-wrap: wrap; }
+  &__radio-group, &__controls { gap: 12px; flex-wrap: wrap; }
+  &__radio-group {
+    position: relative;
+    flex: 0 1 35%;
+    max-width: 35%;
+    flex-wrap: wrap;
+    row-gap: 0;
+  }
+  &__radio-group--expanded { flex-wrap: wrap; }
+  &__radio-group > .ant-radio-group { white-space: nowrap; }
+  &__checkbox-group { display: flex; align-items: center; gap: 16px; white-space: nowrap; }
+  &__checkbox-group .ant-checkbox-wrapper { margin: 0; color: inherit; }
+  .ant-checkbox-input:focus + .ant-checkbox-inner {
+    border-color: #d9d9d9;
+    box-shadow: none;
+  }
+  .ant-checkbox-input:focus-visible + .ant-checkbox-inner {
+    box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.25);
+  }
+  &__checkbox-group .ant-checkbox-checked .ant-checkbox-inner {
+    border-color: var(--filter-option-color, #16a500);
+    background: var(--filter-option-color, #16a500);
+  }
+  .all-check {
+    margin-right: 10px;
+
+    .ant-checkbox-inner::after { background-color: rgba(58, 53, 65, 0.5); }
+    .ant-checkbox-checked .ant-checkbox-inner::after { background-color: transparent; }
+    .ant-checkbox-checked .ant-checkbox-inner {
+      background-color: rgba(58, 53, 65, 0.5);
+      border: none;
+    }
+  }
+  &__radio-group .ant-radio-button-wrapper-checked:not(.ant-radio-button-wrapper-disabled) {
+    color: #fff;
+    background: var(--filter-option-color, #1890ff);
+    border-color: var(--filter-option-color, #1890ff);
+    box-shadow: -1px 0 0 0 var(--filter-option-color, #1890ff);
+  }
+  &__radio-group .filter-bar__select-all-option.ant-radio-button-wrapper-checked:not(.ant-radio-button-wrapper-disabled) {
+    background: #9b9ba1;
+    border-color: #9b9ba1;
+    box-shadow: -1px 0 0 0 #9b9ba1;
+  }
+  & &__more-button {
+    width: 28px;
+    min-width: 28px !important;
+    flex: 0 0 28px;
+    padding: 0;
+  }
+  &__overflow-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    flex: 1 0 100%;
+    max-height: 0;
+    padding-top: 0;
+    opacity: 0;
+    overflow: hidden;
+    visibility: hidden;
+    transform: translateY(-6px);
+    transition:
+      max-height 260ms ease,
+      padding-top 260ms ease,
+      opacity 180ms ease,
+      transform 260ms ease,
+      visibility 0s linear 260ms;
+  }
+  &__overflow-row &__checkbox-group {
+    display: contents;
+  }
+  &__overflow-row--expanded {
+    max-height: 160px;
+    padding-top: 8px;
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    transition:
+      max-height 260ms ease,
+      padding-top 260ms ease,
+      opacity 220ms ease 40ms,
+      transform 260ms ease,
+      visibility 0s;
+  }
+  &__radio-group--expanded &__overflow-row { order: 2; }
+  &__radio-measure { position: absolute; visibility: hidden; pointer-events: none; white-space: nowrap; width: max-content; }
+  &__controls { justify-content: flex-end; flex: 1 1 360px; }
+  &__control { gap: 8px; min-width: 210px; }
+  &__control .ant-select, &__control .ant-input-search { width: 100%; }
+  &__control .ant-input-search > .ant-input-group > .ant-input-affix-wrapper {
+    border-radius: 6px 0 0 6px !important;
+  }
+  &__control .ant-input-search-button {
+    border-radius: 0 6px 6px 0 !important;
+  }
+  &__info-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    color: #6b7280;
+    background: transparent;
+    border: 0;
+    border-radius: 50%;
+    cursor: pointer;
+
+    &:hover, &:focus-visible { color: #1890ff; }
+    &:focus-visible { outline: 2px solid rgba(24, 144, 255, 0.35); outline-offset: 2px; }
+    &:disabled { color: #bfbfbf; cursor: not-allowed; }
+  }
+  &__control-label, &__applied-label { color: #3a3541; font-size: 0.875rem; font-weight: 600; white-space: nowrap; }
+
+  &__applied { gap: 8px; flex-wrap: wrap; margin-top: 14px; padding-top: 12px; border-top: 1px solid #eef0f2; }
+  &__chips { gap: 6px; flex: 1 1 auto; flex-wrap: wrap; }
+  &__chips .ant-tag { margin: 0; padding: 3px 8px; border-radius: 14px; }
+  &__applied .ant-btn { padding: 0 4px; min-width: auto !important; }
+  .ant-skeleton { width: 100%; }
+}
+
+@media (max-width: 767px) {
+  .filter-bar {
+    padding: 12px;
+    &__toolbar, &__radio-group, &__controls, &__control { align-items: stretch; width: 100%; }
+    &__radio-group { max-width: 100%; }
+    &__controls, &__control { flex-direction: column; }
+    &__control--search { flex-direction: row; align-items: center; }
+    &__radio-group { flex-direction: row; align-items: center; flex-wrap: wrap; }
+    &__radio-group--expanded { flex-wrap: wrap; }
+    &__controls { flex-basis: auto; }
+    &__radio-group .ant-radio-group { display: flex; flex-wrap: wrap; }
+    &__radio-group .ant-radio-button-wrapper { flex: 1 1 auto; text-align: center; }
+  }
+}

--- a/web/src/Components/Common/FilterBar/FilterBar.tsx
+++ b/web/src/Components/Common/FilterBar/FilterBar.tsx
@@ -1,0 +1,567 @@
+import { Button, Checkbox, Empty, Input, Popover, Radio, Select, Skeleton, Tag } from "antd";
+import { DoubleRightOutlined, InfoCircleOutlined } from "@ant-design/icons";
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import "./FilterBar.scss";
+
+const { Search } = Input;
+
+export type FilterValue = string | number;
+export type FilterControlValue = FilterValue | FilterValue[] | undefined;
+export type FilterValues = Record<string, FilterControlValue>;
+
+export interface FilterOption {
+  label: ReactNode;
+  value: FilterValue;
+  disabled?: boolean;
+  color?: string;
+}
+
+interface ControlBase {
+  id: string;
+  label?: ReactNode;
+  placeholder?: string;
+  visible?: boolean;
+  disabled?: boolean;
+  width?: number | string;
+  showAsApplied?: boolean;
+  isApplied?: (value: string | FilterValue | FilterValue[]) => boolean;
+}
+
+export interface SearchFilterControl extends ControlBase {
+  type: "search";
+  clearValue?: string;
+  onChange?: (value: string) => void;
+  onSearch?: (value: string) => void;
+  infoVisible?: boolean;
+  infoDescription?: ReactNode;
+}
+
+export interface SingleSelectFilterControl extends ControlBase {
+  type: "select";
+  mode?: "single";
+  clearValue?: FilterValue;
+  options: FilterOption[];
+  onChange?: (value: FilterValue | undefined) => void;
+}
+
+export interface MultiSelectFilterControl extends ControlBase {
+  type: "select";
+  mode: "multiple";
+  clearValue?: FilterValue[];
+  options: FilterOption[];
+  onChange?: (value: FilterValue[]) => void;
+}
+
+export type FilterControl =
+  | SearchFilterControl
+  | SingleSelectFilterControl
+  | MultiSelectFilterControl;
+
+type ResolvedFilterControl =
+  | (SearchFilterControl & { value: string })
+  | (SingleSelectFilterControl & { value?: FilterValue })
+  | (MultiSelectFilterControl & { value: FilterValue[] });
+
+export interface RadioFilterGroup {
+  id: string;
+  label?: ReactNode;
+  options: FilterOption[];
+  onChange?: (value: FilterValue | FilterValue[]) => void;
+  clearValue: FilterValue | FilterValue[];
+  multiple?: boolean;
+  selectAllValue?: FilterValue;
+  overflowPlaceholder?: ReactNode;
+  getAppliedValues?: (value: FilterValue[]) => FilterValue[];
+  onRemoveAppliedValue?: (value: FilterValue) => void;
+  visible?: boolean;
+  disabled?: boolean;
+  showAsApplied?: boolean;
+  isApplied?: (value: FilterValue | FilterValue[]) => boolean;
+}
+
+export interface FilterBarProps {
+  radioGroup?: RadioFilterGroup;
+  controls?: FilterControl[];
+  values: FilterValues;
+  appliedValues?: FilterValues;
+  onChange: (id: string, value: FilterControlValue) => void;
+  loading?: boolean;
+  disabled?: boolean;
+  emptyText?: ReactNode;
+  theme?: "light" | "dark";
+  appliedFiltersLabel: ReactNode;
+  clearAllLabel: ReactNode;
+  onClearAll: () => void;
+  showAppliedFilters?: boolean;
+  className?: string;
+}
+
+interface AppliedChip {
+  key: string;
+  label: ReactNode;
+  remove: () => void;
+}
+
+const optionLabel = (options: FilterOption[], value: FilterValue) =>
+  options.find((option) => option.value === value)?.label ?? String(value);
+
+export const FilterBar = ({
+  radioGroup,
+  controls = [],
+  values,
+  appliedValues = {},
+  onChange,
+  loading = false,
+  disabled = false,
+  emptyText = "No filters available",
+  theme = "light",
+  appliedFiltersLabel,
+  clearAllLabel,
+  onClearAll,
+  showAppliedFilters = true,
+  className = "",
+}: FilterBarProps) => {
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const radioMeasureRef = useRef<HTMLDivElement>(null);
+  const [visibleRadioCount, setVisibleRadioCount] = useState<number>(Number.MAX_SAFE_INTEGER);
+  const [overflowExpanded, setOverflowExpanded] = useState(false);
+  const visibleRadioConfig = radioGroup?.visible !== false ? radioGroup : undefined;
+  const visibleRadio = visibleRadioConfig
+    ? { ...visibleRadioConfig, value: values[visibleRadioConfig.id] ?? visibleRadioConfig.clearValue }
+    : undefined;
+  const visibleControls = controls
+    .filter((control) => control.visible !== false)
+    .map((control): ResolvedFilterControl => {
+      const value = values[control.id];
+      if (control.type === "search") {
+        return { ...control, value: String(value ?? "") };
+      }
+      if (control.mode === "multiple") {
+        return { ...control, value: Array.isArray(value) ? value : [] };
+      }
+      return { ...control, value: Array.isArray(value) ? undefined : value };
+    });
+  const chips: AppliedChip[] = [];
+  const emitChange = (
+    id: string,
+    value: FilterControlValue,
+    controlHandler?: (value: never) => void
+  ) => {
+    if (controlHandler) controlHandler(value as never);
+    else onChange(id, value);
+  };
+  const changeRadio = (value: FilterValue | FilterValue[]) =>
+    emitChange(visibleRadio?.id ?? "", value, visibleRadio?.onChange as ((value: never) => void) | undefined);
+
+  if (
+    visibleRadio &&
+    visibleRadio.showAsApplied !== false &&
+    (visibleRadio.isApplied?.(visibleRadio.value) ?? true)
+  ) {
+    if (Array.isArray(visibleRadio.value)) {
+      const selectedValues = visibleRadio.value;
+      const appliedValues = visibleRadio.getAppliedValues?.(selectedValues)
+        ?? (visibleRadio.selectAllValue !== undefined &&
+          selectedValues.includes(visibleRadio.selectAllValue)
+          ? [visibleRadio.selectAllValue]
+          : selectedValues);
+      appliedValues.forEach((value) => chips.push({
+        key: `group-${visibleRadio.id}-${value}`,
+        label: optionLabel(visibleRadio.options, value),
+        remove: () => visibleRadio.onRemoveAppliedValue
+          ? visibleRadio.onRemoveAppliedValue(value)
+          : visibleRadio.selectAllValue === value
+            ? changeRadio(visibleRadio.clearValue)
+          : changeRadio(
+              selectedValues.filter((selectedValue) => selectedValue !== value)
+            ),
+      }));
+    } else {
+      chips.push({
+        key: `radio-${visibleRadio.id}-${visibleRadio.value}`,
+        label: optionLabel(visibleRadio.options, visibleRadio.value),
+        remove: () => changeRadio(visibleRadio.clearValue),
+      });
+    }
+  }
+
+  visibleControls.forEach((control) => {
+    if (control.showAsApplied === false) return;
+    const chipValue = appliedValues[control.id] ?? control.value;
+    const applied = control.isApplied?.(chipValue) ??
+      (Array.isArray(chipValue) ? chipValue.length > 0 : String(chipValue ?? "").trim() !== "");
+    if (!applied) return;
+
+    if (control.type === "search") {
+      chips.push({
+        key: `${control.id}-${chipValue}`,
+        label: control.label ? <>{control.label}: {chipValue}</> : chipValue,
+        remove: () => {
+          const clearValue = control.clearValue ?? "";
+          emitChange(control.id, clearValue, control.onChange as ((value: never) => void) | undefined);
+          control.onSearch?.(clearValue);
+        },
+      });
+    } else if (control.mode === "multiple") {
+      (control.value as FilterValue[]).forEach((value) => chips.push({
+        key: `${control.id}-${value}`,
+        label: control.label ? <>{control.label}: {optionLabel(control.options, value)}</> : optionLabel(control.options, value),
+        remove: () => emitChange(
+          control.id,
+          (control.value as FilterValue[]).filter((item) => item !== value),
+          control.onChange as ((value: never) => void) | undefined
+        ),
+      }));
+    } else if (control.value !== undefined) {
+      chips.push({
+        key: `${control.id}-${control.value}`,
+        label: control.label
+          ? <>{control.label}: {optionLabel(control.options, control.value as FilterValue)}</>
+          : optionLabel(control.options, control.value as FilterValue),
+        remove: () => emitChange(
+          control.id,
+          control.clearValue,
+          control.onChange as ((value: never) => void) | undefined
+        ),
+      });
+    }
+  });
+
+  const rootClassName = ["filter-bar", `filter-bar--${theme}`, disabled ? "filter-bar--disabled" : "", className]
+    .filter(Boolean)
+    .join(" ");
+
+  useEffect(() => {
+    const toolbar = toolbarRef.current;
+    const measurement = radioMeasureRef.current;
+    if (!toolbar || !measurement || !visibleRadio) {
+      setVisibleRadioCount(Number.MAX_SAFE_INTEGER);
+      return;
+    }
+
+    const updateRadioLayout = () => {
+      const optionElements = Array.from(
+        measurement.querySelectorAll<HTMLElement>(
+          visibleRadio.multiple ? ".ant-checkbox-wrapper" : ".ant-radio-button-wrapper"
+        )
+      );
+      const availableWidth = toolbar.clientWidth * 0.35;
+      const optionGap = visibleRadio.multiple ? 16 : 0;
+      const totalWidth = optionElements.reduce(
+        (sum, option, index) => sum + option.offsetWidth + (index > 0 ? optionGap : 0),
+        0
+      );
+      if (totalWidth <= availableWidth) {
+        setVisibleRadioCount(visibleRadio.options.length);
+        setOverflowExpanded(false);
+        return;
+      }
+
+      const overflowSelectWidth = 28;
+      const gapWidth = 12;
+      const radioBudget = Math.max(0, availableWidth - overflowSelectWidth - gapWidth);
+      let usedWidth = 0;
+      let nextVisibleCount = 0;
+      for (const option of optionElements) {
+        const nextOptionWidth = option.offsetWidth + (nextVisibleCount > 0 ? optionGap : 0);
+        if (usedWidth + nextOptionWidth > radioBudget) break;
+        usedWidth += nextOptionWidth;
+        nextVisibleCount += 1;
+      }
+      setVisibleRadioCount(Math.max(1, nextVisibleCount));
+    };
+    updateRadioLayout();
+
+    const resizeObserver = new ResizeObserver(updateRadioLayout);
+    resizeObserver.observe(toolbar);
+    resizeObserver.observe(measurement);
+    return () => resizeObserver.disconnect();
+  }, [visibleRadio]);
+
+  const visibleRadioOptions = visibleRadio?.options.slice(0, visibleRadioCount) ?? [];
+  const overflowRadioOptions = visibleRadio?.options.slice(visibleRadioCount) ?? [];
+  const selectedGroupValues = visibleRadio && Array.isArray(visibleRadio.value)
+    ? visibleRadio.value
+    : [];
+  const selectableGroupValues = visibleRadio?.options
+    .map((option) => option.value)
+    .filter((value) => value !== visibleRadio?.selectAllValue) ?? [];
+  const selectedOptionCount = selectableGroupValues.filter((value) =>
+    selectedGroupValues.includes(value)
+  ).length;
+  const selectAllIndeterminate = visibleRadio?.selectAllValue !== undefined
+    && !selectedGroupValues.includes(visibleRadio.selectAllValue)
+    && selectedOptionCount > 0
+    && selectedOptionCount < selectableGroupValues.length;
+  const visibleSelectAllOption = visibleRadioOptions.find(
+    (option) => option.value === visibleRadio?.selectAllValue
+  );
+  const visibleStandardOptions = visibleRadioOptions.filter(
+    (option) => option.value !== visibleRadio?.selectAllValue
+  );
+  const optionColorStyle = (option: FilterOption) => option.color
+    && option.value !== visibleRadio?.selectAllValue
+    ? { "--filter-option-color": option.color } as CSSProperties
+    : undefined;
+  const renderCheckboxOptions = (options: FilterOption[]) => options.map((option) => (
+    <Checkbox
+      key={option.value}
+      value={option.value}
+      disabled={option.disabled}
+      style={optionColorStyle(option)}
+    >
+      {option.label}
+    </Checkbox>
+  ));
+  const changeGroupSelection = (values: FilterValue[]) => {
+    if (!visibleRadio) return;
+    const currentValues = Array.isArray(visibleRadio.value) ? visibleRadio.value : [];
+    const selectAllValue = visibleRadio.selectAllValue;
+    if (selectAllValue !== undefined) {
+      const hadSelectAll = currentValues.includes(selectAllValue);
+      const hasSelectAll = values.includes(selectAllValue);
+      if (hasSelectAll && !hadSelectAll) {
+        changeRadio(visibleRadio.options.map((option) => option.value));
+        return;
+      }
+      if (!hasSelectAll && hadSelectAll) {
+        changeRadio(visibleRadio.clearValue);
+        return;
+      }
+      if (hasSelectAll && hadSelectAll) {
+        changeRadio(values.filter((value) => value !== selectAllValue));
+        return;
+      }
+      const individualValues = visibleRadio.options
+        .map((option) => option.value)
+        .filter((value) => value !== selectAllValue);
+      if (
+        individualValues.length > 0 &&
+        individualValues.every((value) => values.includes(value))
+      ) {
+        changeRadio(visibleRadio.options.map((option) => option.value));
+        return;
+      }
+    }
+    changeRadio(values);
+  };
+  const changeSelectionRow = (
+    rowValues: FilterValue[],
+    rowOptions: FilterOption[]
+  ) => {
+    if (!visibleRadio || !Array.isArray(visibleRadio.value)) return;
+    const rowOptionValues = new Set(rowOptions.map((option) => option.value));
+    const selectionsFromOtherRows = visibleRadio.value.filter(
+      (value) => !rowOptionValues.has(value)
+    );
+    changeGroupSelection(Array.from(new Set([
+      ...selectionsFromOtherRows,
+      ...rowValues,
+    ])));
+  };
+  const overflowButton = visibleRadio && overflowRadioOptions.length > 0 ? (
+    <Button
+      className="filter-bar__more-button"
+      size="small"
+      shape="circle"
+      aria-label={String(visibleRadio.overflowPlaceholder ?? "More options")}
+      title={String(visibleRadio.overflowPlaceholder ?? "More options")}
+      icon={<DoubleRightOutlined rotate={overflowExpanded ? -90 : 90} />}
+      disabled={disabled || visibleRadio.disabled}
+      onClick={() => setOverflowExpanded((expanded) => !expanded)}
+    />
+  ) : null;
+
+  if (loading) {
+    return <div className={rootClassName}><Skeleton active paragraph={{ rows: 1 }} title={false} /></div>;
+  }
+
+  if (!visibleRadio && visibleControls.length === 0) {
+    return <div className={rootClassName}><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={emptyText} /></div>;
+  }
+
+  return (
+    <div className={rootClassName}>
+      <div className="filter-bar__toolbar" ref={toolbarRef}>
+        {visibleRadio && (
+          <div className={`filter-bar__radio-group${overflowExpanded ? " filter-bar__radio-group--expanded" : ""}`}>
+            {visibleRadio.label && <span className="filter-bar__control-label">{visibleRadio.label}</span>}
+            {visibleRadio.multiple ? (
+              <>
+                {visibleSelectAllOption && (
+                  <Checkbox
+                    className="all-check"
+                    disabled={disabled || visibleRadio.disabled || visibleSelectAllOption.disabled}
+                    indeterminate={selectAllIndeterminate}
+                    checked={selectedGroupValues.includes(visibleSelectAllOption.value)}
+                    onChange={(event) => changeRadio(
+                      event.target.checked
+                        ? visibleRadio.options.map((option) => option.value)
+                        : visibleRadio.clearValue
+                    )}
+                  >
+                    {visibleSelectAllOption.label}
+                  </Checkbox>
+                )}
+                {visibleStandardOptions.length > 0 && (
+                  <Checkbox.Group
+                    className="filter-bar__checkbox-group"
+                    value={visibleRadio.value as FilterValue[]}
+                    disabled={disabled || visibleRadio.disabled}
+                    onChange={(values) => changeSelectionRow(
+                      values as FilterValue[],
+                      visibleStandardOptions
+                    )}
+                  >
+                    {renderCheckboxOptions(visibleStandardOptions)}
+                  </Checkbox.Group>
+                )}
+              </>
+            ) : (
+              <Radio.Group
+                buttonStyle="solid"
+                value={visibleRadio.value}
+                disabled={disabled || visibleRadio.disabled}
+                onChange={(event) => changeRadio(event.target.value)}
+              >
+                {visibleRadioOptions.map((option) => (
+                  <Radio.Button
+                    key={option.value}
+                    value={option.value}
+                    disabled={option.disabled}
+                    className={option.value === visibleRadio.selectAllValue
+                      ? "filter-bar__select-all-option"
+                      : undefined}
+                    style={optionColorStyle(option)}
+                  >
+                    {option.label}
+                  </Radio.Button>
+                ))}
+              </Radio.Group>
+            )}
+            {!overflowExpanded && overflowButton}
+            {overflowRadioOptions.length > 0 && (
+              <div
+                className={`filter-bar__overflow-row${overflowExpanded ? " filter-bar__overflow-row--expanded" : ""}`}
+                aria-hidden={!overflowExpanded}
+              >
+                {visibleRadio.multiple ? (
+                  <Checkbox.Group
+                    className="filter-bar__checkbox-group"
+                    value={visibleRadio.value as FilterValue[]}
+                    disabled={disabled || visibleRadio.disabled}
+                    onChange={(values) => changeSelectionRow(
+                      values as FilterValue[],
+                      overflowRadioOptions
+                    )}
+                  >
+                    {renderCheckboxOptions(overflowRadioOptions)}
+                  </Checkbox.Group>
+                ) : (
+                  <Radio.Group
+                    value={visibleRadio.value}
+                    disabled={disabled || visibleRadio.disabled}
+                    onChange={(event) => changeRadio(event.target.value)}
+                  >
+                    {overflowRadioOptions.map((option) => (
+                      <Radio.Button
+                        key={option.value}
+                        value={option.value}
+                        disabled={option.disabled}
+                        className={option.value === visibleRadio.selectAllValue
+                          ? "filter-bar__select-all-option"
+                          : undefined}
+                        style={optionColorStyle(option)}
+                      >
+                        {option.label}
+                      </Radio.Button>
+                    ))}
+                  </Radio.Group>
+                )}
+                {overflowButton}
+              </div>
+            )}
+            <div className="filter-bar__radio-measure" ref={radioMeasureRef} aria-hidden="true">
+              {visibleRadio.multiple
+                ? <Checkbox.Group options={visibleRadio.options} />
+                : <Radio.Group optionType="button" options={visibleRadio.options} />}
+            </div>
+          </div>
+        )}
+        <div className="filter-bar__controls">
+          {visibleControls.map((control) => (
+            <div
+              className={`filter-bar__control${control.type === "search" ? " filter-bar__control--search" : ""}`}
+              key={control.id}
+              style={control.type === "search"
+                ? { flex: "0 0 auto" }
+                : control.width
+                  ? { width: control.width, flex: "0 0 auto" }
+                  : undefined}
+            >
+              {control.label && <span className="filter-bar__control-label">{control.label}</span>}
+              {control.type === "search" ? (
+                <>
+                  {control.infoVisible && control.infoDescription != null && (
+                    <Popover content={control.infoDescription} trigger="click">
+                      <button
+                        type="button"
+                        className="filter-bar__info-button"
+                        aria-label="Search information"
+                        disabled={disabled || control.disabled}
+                      >
+                        <InfoCircleOutlined />
+                      </button>
+                    </Popover>
+                  )}
+                  <Search
+                    allowClear
+                    value={String(control.value ?? "")}
+                    placeholder={control.placeholder}
+                    disabled={disabled || control.disabled}
+                    style={control.width ? { width: control.width } : undefined}
+                    onChange={(event) => emitChange(
+                      control.id,
+                      event.target.value,
+                      control.onChange as ((value: never) => void) | undefined
+                    )}
+                    onPressEnter={(event) => control.onSearch?.(
+                      (event.target as HTMLInputElement).value
+                    )}
+                    onSearch={(value, event) => {
+                      if (event?.type !== "keydown") control.onSearch?.(value);
+                    }}
+                  />
+                </>
+              ) : (
+                <Select
+                  allowClear={control.mode !== "multiple"}
+                  mode={control.mode === "multiple" ? "multiple" : undefined}
+                  maxTagCount="responsive"
+                  value={control.value}
+                  options={control.options}
+                  placeholder={control.placeholder}
+                  disabled={disabled || control.disabled}
+                  onChange={(value) => emitChange(
+                    control.id,
+                    value as FilterControlValue,
+                    control.onChange as ((value: never) => void) | undefined
+                  )}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+      {showAppliedFilters && chips.length > 0 && (
+        <div className="filter-bar__applied">
+          <span className="filter-bar__applied-label">{appliedFiltersLabel}</span>
+          <div className="filter-bar__chips">
+            {chips.map((chip) => <Tag key={chip.key} closable={!disabled} onClose={chip.remove}>{chip.label}</Tag>)}
+          </div>
+          <Button type="link" disabled={disabled} onClick={onClearAll}>{clearAllLabel}</Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web/src/Components/Common/FilterBar/index.ts
+++ b/web/src/Components/Common/FilterBar/index.ts
@@ -1,0 +1,13 @@
+export { FilterBar } from "./FilterBar";
+export type {
+  FilterBarProps,
+  FilterControl,
+  FilterOption,
+  FilterControlValue,
+  FilterValue,
+  FilterValues,
+  MultiSelectFilterControl,
+  RadioFilterGroup,
+  SearchFilterControl,
+  SingleSelectFilterControl,
+} from "./FilterBar";


### PR DESCRIPTION
- Add a reusable, controlled React and TypeScript filter bar.
- Support configurable checkbox/radio options, search inputs, and single/multi-select dropdowns.
- Add responsive overflow handling for selection options.
- Add applied-filter chips, individual removal, and Clear All.
- Support option colors, select-all behavior, loading, disabled, empty, light, and dark states.
- Submit project searches only on Enter or search-icon click.
- Add an optional information popover for search controls.
- Preserve selections across visible and overflow checkbox rows.