### PR TITLE
Credit issuance query endpoint

### DIFF
--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.module.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.module.ts
@@ -11,6 +11,7 @@ import { CreditBlockBalancesViewEntity } from "../view-entities/credit.block.bal
 import { CreditBlockTransfersViewEntity } from "../view-entities/credit.block.transfers.view.entity";
 import { CreditBlockRetirementsViewEntity } from "../view-entities/credit.block.retirements.view.entity";
 import { CreditBlockExplorerViewEntity } from "../view-entities/credit.block.explorer.view.entity";
+import { CreditBlockIssuancesViewEntity } from "../view-entities/credit.block.issuances.view.entity";
 import { DocumentManagementModule } from "../document-management/document-management.module";
 import { AefReportManagementModule } from "../aef-report-management/aef-report-management.module";
 import { CooperativeApproach } from "../entities/cooperative.approach.entity";
@@ -29,6 +30,7 @@ import { SerialNumberManagementModule } from "../serial-number-management/serial
       CreditBlockTransfersViewEntity,
       CreditBlockRetirementsViewEntity,
       CreditBlockExplorerViewEntity,
+      CreditBlockIssuancesViewEntity,
       CooperativeApproach,
     ]),
     DocumentManagementModule,

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
@@ -25,6 +25,7 @@ import { FilterEntry } from "../dto/filter.entry";
 import { CreditBlockTransfersViewEntity } from "../view-entities/credit.block.transfers.view.entity";
 import { CreditBlockRetirementsViewEntity } from "../view-entities/credit.block.retirements.view.entity";
 import { CreditBlockExplorerViewEntity } from "../view-entities/credit.block.explorer.view.entity";
+import { CreditBlockIssuancesViewEntity } from "../view-entities/credit.block.issuances.view.entity";
 import { DocumentManagementService } from "../document-management/document-management.service";
 import { ProjectAuditLogType } from "../enum/project.audit.log.type.enum";
 import { DataResponseDto } from "../dto/data.response.dto";
@@ -106,6 +107,8 @@ export class CreditTransactionsManagementService {
     private creditBlockRetirementsViewEntityRepository: Repository<CreditBlockRetirementsViewEntity>,
     @InjectRepository(CreditBlockExplorerViewEntity)
     private creditBlockExplorerViewEntityRepository: Repository<CreditBlockExplorerViewEntity>,
+    @InjectRepository(CreditBlockIssuancesViewEntity)
+    private creditBlockIssuancesViewEntityRepository: Repository<CreditBlockIssuancesViewEntity>,
     private readonly aefReportManagementService: AefReportManagementService,
     // Draft -/CMA.5 paras 20-21 guard: refuse /transfer when the block's
     // linked cooperative approach has been revoked. Mirrors the
@@ -727,6 +730,50 @@ export class CreditTransactionsManagementService {
         query?.sort?.key && query.sort.key == "status"
           ? `"${query.sort.key}"::text`
           : `"${query.sort.key}"`,
+        query?.sort?.order,
+        query?.sort?.nullFirst !== undefined
+          ? query?.sort?.nullFirst === true
+            ? "NULLS FIRST"
+            : "NULLS LAST"
+          : undefined
+      )
+      .skip(query.size * query.page - query.size)
+      .take(query.size)
+      .getManyAndCount();
+    return new DataListResponseDto(
+      resp.length > 0 ? resp[0] : undefined,
+      resp.length > 1 ? resp[1] : undefined
+    );
+  }
+
+  public async queryIssuances(
+    query: QueryDto,
+    abilityCondition: string,
+    user: User
+  ): Promise<DataListResponseDto> {
+    if (user.companyRole == CompanyRole.PROJECT_DEVELOPER) {
+      const onlyOwn: FilterEntry = {
+        key: "organizationId",
+        value: user.companyId,
+        operation: "=",
+      };
+      query.filterAnd
+        ? query.filterAnd.push(onlyOwn)
+        : (query.filterAnd = [onlyOwn]);
+    } else if (user.companyRole == CompanyRole.INDEPENDENT_CERTIFIER) {
+      throw new HttpException(
+        this.helperService.formatReqMessagesString(
+          "creditTransaction.unauthorized",
+          []
+        ),
+        HttpStatus.BAD_REQUEST
+      );
+    }
+    const resp = await this.creditBlockIssuancesViewEntityRepository
+      .createQueryBuilder("creditTx")
+      .where(this.helperService.generateWhereSQL(query, abilityCondition))
+      .orderBy(
+        query?.sort?.key && `"${query?.sort?.key}"`,
         query?.sort?.order,
         query?.sort?.nullFirst !== undefined
           ? query?.sort?.nullFirst === true

--- a/backend/services/libs/shared/src/view-entities/credit.block.issuances.view.entity.ts
+++ b/backend/services/libs/shared/src/view-entities/credit.block.issuances.view.entity.ts
@@ -1,0 +1,48 @@
+import { ViewColumn, ViewEntity } from "typeorm";
+
+@ViewEntity({
+  expression: `
+      SELECT
+        ct."id" AS "id",
+        ct."serialNumber" AS "serialNumber",
+        ct."amount" AS "creditAmount",
+        ct."createTime" AS "issuanceDate",
+        ct."projectRefId" AS "projectId",
+        p."title" AS "projectName",
+        ct."recieverId" AS "organizationId",
+        r."name" AS "organizationName",
+        r."logo" AS "organizationLogo"
+      FROM "credit_transactions_entity" ct
+      LEFT JOIN project_entity p ON ct."projectRefId" = p."refId"
+      LEFT JOIN company r ON ct."recieverId" = r."companyId"
+      WHERE ct."type" = 'Issued'
+    `,
+})
+export class CreditBlockIssuancesViewEntity {
+  @ViewColumn()
+  id: string;
+
+  @ViewColumn()
+  serialNumber: string;
+
+  @ViewColumn()
+  creditAmount: number;
+
+  @ViewColumn()
+  issuanceDate: number;
+
+  @ViewColumn()
+  projectId: string;
+
+  @ViewColumn()
+  projectName: string;
+
+  @ViewColumn()
+  organizationId: number;
+
+  @ViewColumn()
+  organizationName: string;
+
+  @ViewColumn()
+  organizationLogo: string;
+}

--- a/backend/services/src/migrations/1784711176589-AddCreditBlockIssuancesView.ts
+++ b/backend/services/src/migrations/1784711176589-AddCreditBlockIssuancesView.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCreditBlockIssuancesView1784711176589 implements MigrationInterface {
+    name = 'AddCreditBlockIssuancesView1784711176589'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE VIEW "credit_block_issuances_view_entity" AS
+    SELECT
+        ct."id" AS "id",
+        ct."serialNumber" AS "serialNumber",
+        ct."amount" AS "creditAmount",
+        ct."createTime" AS "issuanceDate",
+        ct."projectRefId" AS "projectId",
+        p."title" AS "projectName",
+        ct."recieverId" AS "organizationId",
+        r."name" AS "organizationName",
+        r."logo" AS "organizationLogo"
+      FROM "credit_transactions_entity" ct
+      LEFT JOIN project_entity p ON ct."projectRefId" = p."refId"
+      LEFT JOIN company r ON ct."recieverId" = r."companyId"
+      WHERE ct."type" = 'Issued'`);
+        await queryRunner.query(`INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`, ["public","VIEW","credit_block_issuances_view_entity","SELECT\n        ct.\"id\" AS \"id\",\n        ct.\"serialNumber\" AS \"serialNumber\",\n        ct.\"amount\" AS \"creditAmount\",\n        ct.\"createTime\" AS \"issuanceDate\",\n        ct.\"projectRefId\" AS \"projectId\",\n        p.\"title\" AS \"projectName\",\n        ct.\"recieverId\" AS \"organizationId\",\n        r.\"name\" AS \"organizationName\",\n        r.\"logo\" AS \"organizationLogo\"\n      FROM \"credit_transactions_entity\" ct\n      LEFT JOIN project_entity p ON ct.\"projectRefId\" = p.\"refId\"\n      LEFT JOIN company r ON ct.\"recieverId\" = r.\"companyId\"\n      WHERE ct.\"type\" = 'Issued'"]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`, ["VIEW","credit_block_issuances_view_entity","public"]);
+        await queryRunner.query(`DROP VIEW "credit_block_issuances_view_entity"`);
+    }
+
+}

--- a/backend/services/src/national-api/credit.transactions.management.controller.ts
+++ b/backend/services/src/national-api/credit.transactions.management.controller.ts
@@ -117,6 +117,23 @@ export class CreditTransactionsManagementController {
   @CheckPolicies((ability: AppAbility) =>
     ability.can(Action.Read, ProjectEntity)
   )
+  @Post("queryIssuances")
+  async queryIssuances(
+    @Body() queryDto: QueryDto,
+    @Request() req
+  ): Promise<any> {
+    return this.creditTransactionsManagementService.queryIssuances(
+      queryDto,
+      req.abilityCondition,
+      req.user
+    );
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, PoliciesGuard)
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, ProjectEntity)
+  )
   @Post("queryExplorer")
   async queryExplorer(
     @Body() queryDto: QueryDto,


### PR DESCRIPTION
Feeds the redesigned Credits → Issuances tab: a paginated list of every issuance event (project, organization, serial number, issuance date, credits issued), backed by a new credit_block_issuances_view_entity read view over the existing issuance records in credit_transactions_entity (the same rows written whenever a ledger ISSUE event is replicated). These rows keep the original issued serial and amount even after a block is later split by transfers or retirements, so the tab always shows what was actually issued.

 Access follows the same pattern as the other list endpoints: Project Developers only see issuances made to their own company, Independent Certifiers are blocked, and every other role (DNA, etc.) sees the full registry. Supports the standard QueryDto filtering/sorting/pagination, so the frontend's Organization and Project filter dropdowns work the same way they do on the other Credits tabs.

[Jira Task](https://github.com/xeptagondev/carbon-registry-undp/pull/97)