### PR TITLE
Credit balace by organization and by project endpoints

### DIFF
--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.module.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.module.ts
@@ -12,6 +12,9 @@ import { CreditBlockTransfersViewEntity } from "../view-entities/credit.block.tr
 import { CreditBlockRetirementsViewEntity } from "../view-entities/credit.block.retirements.view.entity";
 import { CreditBlockExplorerViewEntity } from "../view-entities/credit.block.explorer.view.entity";
 import { CreditBlockIssuancesViewEntity } from "../view-entities/credit.block.issuances.view.entity";
+import { CreditBlockOrgBalancesViewEntity } from "../view-entities/credit.block.org.balances.view.entity";
+import { CreditBlockProjectBalancesViewEntity } from "../view-entities/credit.block.project.balances.view.entity";
+import { CreditBlockProjectHolderBalancesViewEntity } from "../view-entities/credit.block.project.holder.balances.view.entity";
 import { DocumentManagementModule } from "../document-management/document-management.module";
 import { AefReportManagementModule } from "../aef-report-management/aef-report-management.module";
 import { CooperativeApproach } from "../entities/cooperative.approach.entity";
@@ -31,6 +34,9 @@ import { SerialNumberManagementModule } from "../serial-number-management/serial
       CreditBlockRetirementsViewEntity,
       CreditBlockExplorerViewEntity,
       CreditBlockIssuancesViewEntity,
+      CreditBlockOrgBalancesViewEntity,
+      CreditBlockProjectBalancesViewEntity,
+      CreditBlockProjectHolderBalancesViewEntity,
       CooperativeApproach,
     ]),
     DocumentManagementModule,

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
@@ -26,6 +26,9 @@ import { CreditBlockTransfersViewEntity } from "../view-entities/credit.block.tr
 import { CreditBlockRetirementsViewEntity } from "../view-entities/credit.block.retirements.view.entity";
 import { CreditBlockExplorerViewEntity } from "../view-entities/credit.block.explorer.view.entity";
 import { CreditBlockIssuancesViewEntity } from "../view-entities/credit.block.issuances.view.entity";
+import { CreditBlockOrgBalancesViewEntity } from "../view-entities/credit.block.org.balances.view.entity";
+import { CreditBlockProjectBalancesViewEntity } from "../view-entities/credit.block.project.balances.view.entity";
+import { CreditBlockProjectHolderBalancesViewEntity } from "../view-entities/credit.block.project.holder.balances.view.entity";
 import { DocumentManagementService } from "../document-management/document-management.service";
 import { ProjectAuditLogType } from "../enum/project.audit.log.type.enum";
 import { DataResponseDto } from "../dto/data.response.dto";
@@ -109,6 +112,12 @@ export class CreditTransactionsManagementService {
     private creditBlockExplorerViewEntityRepository: Repository<CreditBlockExplorerViewEntity>,
     @InjectRepository(CreditBlockIssuancesViewEntity)
     private creditBlockIssuancesViewEntityRepository: Repository<CreditBlockIssuancesViewEntity>,
+    @InjectRepository(CreditBlockOrgBalancesViewEntity)
+    private creditBlockOrgBalancesViewEntityRepository: Repository<CreditBlockOrgBalancesViewEntity>,
+    @InjectRepository(CreditBlockProjectBalancesViewEntity)
+    private creditBlockProjectBalancesViewEntityRepository: Repository<CreditBlockProjectBalancesViewEntity>,
+    @InjectRepository(CreditBlockProjectHolderBalancesViewEntity)
+    private creditBlockProjectHolderBalancesViewEntityRepository: Repository<CreditBlockProjectHolderBalancesViewEntity>,
     private readonly aefReportManagementService: AefReportManagementService,
     // Draft -/CMA.5 paras 20-21 guard: refuse /transfer when the block's
     // linked cooperative approach has been revoked. Mirrors the
@@ -638,6 +647,132 @@ export class CreditTransactionsManagementService {
     }
     const resp = await this.creditBlockBalancesViewEntityRepository
       .createQueryBuilder("creditBlock")
+      .where(this.helperService.generateWhereSQL(query, abilityCondition))
+      .orderBy(
+        query?.sort?.key && `"${query?.sort?.key}"`,
+        query?.sort?.order,
+        query?.sort?.nullFirst !== undefined
+          ? query?.sort?.nullFirst === true
+            ? "NULLS FIRST"
+            : "NULLS LAST"
+          : undefined
+      )
+      .skip(query.size * query.page - query.size)
+      .take(query.size)
+      .getManyAndCount();
+    return new DataListResponseDto(
+      resp.length > 0 ? resp[0] : undefined,
+      resp.length > 1 ? resp[1] : undefined
+    );
+  }
+
+  /**
+   * Credits -> Balance -> By Organization (DNA only): one row per
+   * organization, aggregating the balance and reserved amount of every
+   * non-retired block it owns, via CreditBlockOrgBalancesViewEntity.
+   * updatedTime is the most recent block update within that
+   * organization's owned blocks. Ignores the page's account-type filter
+   * by design - totals always cover all account types.
+   */
+  public async queryBalanceByOrganization(
+    query: QueryDto,
+    abilityCondition: string,
+    user: User
+  ): Promise<DataListResponseDto> {
+    if (user.companyRole != CompanyRole.DESIGNATED_NATIONAL_AUTHORITY) {
+      throw new HttpException(
+        this.helperService.formatReqMessagesString(
+          "creditTransaction.unauthorized",
+          []
+        ),
+        HttpStatus.BAD_REQUEST
+      );
+    }
+    const resp = await this.creditBlockOrgBalancesViewEntityRepository
+      .createQueryBuilder("orgBalance")
+      .where(this.helperService.generateWhereSQL(query, abilityCondition))
+      .orderBy(
+        query?.sort?.key && `"${query?.sort?.key}"`,
+        query?.sort?.order,
+        query?.sort?.nullFirst !== undefined
+          ? query?.sort?.nullFirst === true
+            ? "NULLS FIRST"
+            : "NULLS LAST"
+          : undefined
+      )
+      .skip(query.size * query.page - query.size)
+      .take(query.size)
+      .getManyAndCount();
+    return new DataListResponseDto(
+      resp.length > 0 ? resp[0] : undefined,
+      resp.length > 1 ? resp[1] : undefined
+    );
+  }
+
+  /**
+   * Credits -> Balance -> By Project: one row per project, aggregating
+   * the balance and reserved amount of every non-retired block within
+   * it. projectOwner* always identifies the project's developer company
+   * (project_entity.companyId), not the current credit holder(s). DNA
+   * sees totals across every holding organization
+   * (CreditBlockProjectBalancesViewEntity); Project Developers are
+   * scoped to blocks their own company holds
+   * (CreditBlockProjectHolderBalancesViewEntity, filtered to
+   * holderId = own companyId - a pre-aggregation scope baked into the
+   * view's grain, so totals only ever reflect their own credits).
+   * updatedTime is the most recent block update within that project's
+   * (scoped) blocks. Ignores the page's account-type filter by design -
+   * totals always cover all account types. The inner per-block
+   * breakdown for a project is fed by the existing
+   * queryBalance/queryCreditBalances endpoint filtered by projectId.
+   */
+  public async queryBalanceByProject(
+    query: QueryDto,
+    abilityCondition: string,
+    user: User
+  ): Promise<DataListResponseDto> {
+    if (user.companyRole == CompanyRole.INDEPENDENT_CERTIFIER) {
+      throw new HttpException(
+        this.helperService.formatReqMessagesString(
+          "creditTransaction.unauthorized",
+          []
+        ),
+        HttpStatus.BAD_REQUEST
+      );
+    }
+
+    if (user.companyRole == CompanyRole.PROJECT_DEVELOPER) {
+      const onlyOwn: FilterEntry = {
+        key: "holderId",
+        value: user.companyId,
+        operation: "=",
+      };
+      query.filterAnd
+        ? query.filterAnd.push(onlyOwn)
+        : (query.filterAnd = [onlyOwn]);
+      const resp = await this.creditBlockProjectHolderBalancesViewEntityRepository
+        .createQueryBuilder("projectBalance")
+        .where(this.helperService.generateWhereSQL(query, abilityCondition))
+        .orderBy(
+          query?.sort?.key && `"${query?.sort?.key}"`,
+          query?.sort?.order,
+          query?.sort?.nullFirst !== undefined
+            ? query?.sort?.nullFirst === true
+              ? "NULLS FIRST"
+              : "NULLS LAST"
+            : undefined
+        )
+        .skip(query.size * query.page - query.size)
+        .take(query.size)
+        .getManyAndCount();
+      return new DataListResponseDto(
+        resp.length > 0 ? resp[0] : undefined,
+        resp.length > 1 ? resp[1] : undefined
+      );
+    }
+
+    const resp = await this.creditBlockProjectBalancesViewEntityRepository
+      .createQueryBuilder("projectBalance")
       .where(this.helperService.generateWhereSQL(query, abilityCondition))
       .orderBy(
         query?.sort?.key && `"${query?.sort?.key}"`,

--- a/backend/services/libs/shared/src/view-entities/credit.block.balances.view.entity.ts
+++ b/backend/services/libs/shared/src/view-entities/credit.block.balances.view.entity.ts
@@ -7,7 +7,9 @@ import { ViewColumn, ViewEntity } from "typeorm";
       cb."serialNumber" AS "serialNumber",
       cb."itmoSerial" AS "itmoSerial",
       (cb."creditAmount" - cb."reservedCreditAmount") AS "creditAmount",
+      cb."reservedCreditAmount" AS "reservedCredits",
       cb."createTime" AS "createdDate",
+      cb."txTime" AS "updatedTime",
       cb."projectRefId" AS "projectId",
       p."title" AS "projectName",
       cb."ownerCompanyId" AS "receiverId",
@@ -46,7 +48,13 @@ export class CreditBlockBalancesViewEntity {
   creditAmount: number;
 
   @ViewColumn()
+  reservedCredits: number;
+
+  @ViewColumn()
   createdDate: number;
+
+  @ViewColumn()
+  updatedTime: number;
 
   @ViewColumn()
   projectId: string;

--- a/backend/services/libs/shared/src/view-entities/credit.block.org.balances.view.entity.ts
+++ b/backend/services/libs/shared/src/view-entities/credit.block.org.balances.view.entity.ts
@@ -1,0 +1,40 @@
+import { ViewColumn, ViewEntity } from "typeorm";
+
+// Credits -> Balance -> By Organization (DNA only): one row per
+// credit-holding organization, aggregating the balance (creditAmount -
+// reservedCreditAmount) and reserved amount of every non-retired block it
+// owns. updatedTime is the most recent block update (txTime) among those
+// blocks. Ignores account type by design - totals cover all account types.
+@ViewEntity({
+  expression: `
+    SELECT
+      cb."ownerCompanyId" AS "organizationId",
+      o."name" AS "organizationName",
+      o."logo" AS "organizationLogo",
+      SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance",
+      SUM(cb."reservedCreditAmount") AS "reservedCredits",
+      MAX(cb."txTime") AS "updatedTime"
+    FROM credit_blocks_entity cb
+    LEFT JOIN company o ON cb."ownerCompanyId" = o."companyId"
+    WHERE cb."ownerCompanyId" != 0
+    GROUP BY cb."ownerCompanyId", o."name", o."logo"`,
+})
+export class CreditBlockOrgBalancesViewEntity {
+  @ViewColumn()
+  organizationId: number;
+
+  @ViewColumn()
+  organizationName: string;
+
+  @ViewColumn()
+  organizationLogo: string;
+
+  @ViewColumn()
+  creditBalance: number;
+
+  @ViewColumn()
+  reservedCredits: number;
+
+  @ViewColumn()
+  updatedTime: number;
+}

--- a/backend/services/libs/shared/src/view-entities/credit.block.project.balances.view.entity.ts
+++ b/backend/services/libs/shared/src/view-entities/credit.block.project.balances.view.entity.ts
@@ -1,0 +1,54 @@
+import { ViewColumn, ViewEntity } from "typeorm";
+
+// Credits -> Balance -> By Project (DNA): one row per project, aggregating
+// the balance (creditAmount - reservedCreditAmount) and reserved amount of
+// every non-retired block within it, across ALL holding organizations.
+// projectOwner* identifies the project's developer company
+// (project_entity.companyId), not the current credit holder(s) - a project
+// can have credits split across several holders. updatedTime is the most
+// recent block update (txTime) within the project. Ignores account type by
+// design - totals cover all account types. Project Developers must NOT use
+// this view (it is not scoped to a holder) - see
+// CreditBlockProjectHolderBalancesViewEntity.
+@ViewEntity({
+  expression: `
+    SELECT
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      p."companyId" AS "projectOwnerId",
+      pc."name" AS "projectOwnerName",
+      pc."logo" AS "projectOwnerLogo",
+      SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance",
+      SUM(cb."reservedCreditAmount") AS "reservedCredits",
+      MAX(cb."txTime") AS "updatedTime"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company pc ON p."companyId" = pc."companyId"
+    WHERE cb."ownerCompanyId" != 0
+    GROUP BY cb."projectRefId", p."title", p."companyId", pc."name", pc."logo"`,
+})
+export class CreditBlockProjectBalancesViewEntity {
+  @ViewColumn()
+  projectId: string;
+
+  @ViewColumn()
+  projectName: string;
+
+  @ViewColumn()
+  projectOwnerId: number;
+
+  @ViewColumn()
+  projectOwnerName: string;
+
+  @ViewColumn()
+  projectOwnerLogo: string;
+
+  @ViewColumn()
+  creditBalance: number;
+
+  @ViewColumn()
+  reservedCredits: number;
+
+  @ViewColumn()
+  updatedTime: number;
+}

--- a/backend/services/libs/shared/src/view-entities/credit.block.project.holder.balances.view.entity.ts
+++ b/backend/services/libs/shared/src/view-entities/credit.block.project.holder.balances.view.entity.ts
@@ -1,0 +1,63 @@
+import { ViewColumn, ViewEntity } from "typeorm";
+
+// Credits -> Balance -> By Project (Project Developer): one row per
+// (project, holder) pair, aggregating the balance (creditAmount -
+// reservedCreditAmount) and reserved amount of every non-retired block a
+// given organization holds within a given project. A Project Developer
+// queries this filtered to holderId = own companyId, yielding one row per
+// project it holds credits in, scoped strictly to its own holdings -
+// unlike CreditBlockProjectBalancesViewEntity (DNA), which sums across all
+// holders. projectOwner* still identifies the project's developer company,
+// which may differ from the current holder. updatedTime is the most recent
+// block update (txTime) within the (project, holder) scope. Ignores
+// account type by design - totals cover all account types.
+@ViewEntity({
+  expression: `
+    SELECT
+      cb."projectRefId" || '-' || cb."ownerCompanyId" AS "id",
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      p."companyId" AS "projectOwnerId",
+      pc."name" AS "projectOwnerName",
+      pc."logo" AS "projectOwnerLogo",
+      cb."ownerCompanyId" AS "holderId",
+      SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance",
+      SUM(cb."reservedCreditAmount") AS "reservedCredits",
+      MAX(cb."txTime") AS "updatedTime"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company pc ON p."companyId" = pc."companyId"
+    WHERE cb."ownerCompanyId" != 0
+    GROUP BY cb."projectRefId", p."title", p."companyId", pc."name", pc."logo", cb."ownerCompanyId"`,
+})
+export class CreditBlockProjectHolderBalancesViewEntity {
+  @ViewColumn()
+  id: string;
+
+  @ViewColumn()
+  projectId: string;
+
+  @ViewColumn()
+  projectName: string;
+
+  @ViewColumn()
+  projectOwnerId: number;
+
+  @ViewColumn()
+  projectOwnerName: string;
+
+  @ViewColumn()
+  projectOwnerLogo: string;
+
+  @ViewColumn()
+  holderId: number;
+
+  @ViewColumn()
+  creditBalance: number;
+
+  @ViewColumn()
+  reservedCredits: number;
+
+  @ViewColumn()
+  updatedTime: number;
+}

--- a/backend/services/src/migrations/1784870412942-CreditBalanceAggregationViews.ts
+++ b/backend/services/src/migrations/1784870412942-CreditBalanceAggregationViews.ts
@@ -1,0 +1,310 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// Credits -> Balance redesign: adds the By Organization and By Project
+// aggregation views, and extends the existing per-block balances view
+// with reservedCredits/updatedTime so the design's inner (expanded)
+// per-block table has what it needs. Written by hand rather than via
+// `migration:generate` - the local dev DB runs with synchronize=true
+// (NODE_ENV=dev), so it had already auto-synced these exact views,
+// leaving nothing for the generator to diff (and it surfaced unrelated
+// pre-existing drift instead). The CREATE VIEW SQL below is copied
+// verbatim from the corresponding view-entity `expression`, matching the
+// convention set by 1784711176589-AddCreditBlockIssuancesView.ts.
+export class CreditBalanceAggregationViews1784870412942
+  implements MigrationInterface
+{
+  name = "CreditBalanceAggregationViews1784870412942";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // --- Replace credit_block_balances_view_entity with the extended
+    // version (adds reservedCredits, updatedTime) ---
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["VIEW", "credit_block_balances_view_entity", "public"]
+    );
+    await queryRunner.query(`DROP VIEW "credit_block_balances_view_entity"`);
+
+    await queryRunner.query(`CREATE VIEW "credit_block_balances_view_entity" AS
+    SELECT
+      cb."creditBlockId" AS "id",
+      cb."serialNumber" AS "serialNumber",
+      cb."itmoSerial" AS "itmoSerial",
+      (cb."creditAmount" - cb."reservedCreditAmount") AS "creditAmount",
+      cb."reservedCreditAmount" AS "reservedCredits",
+      cb."createTime" AS "createdDate",
+      cb."txTime" AS "updatedTime",
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      cb."ownerCompanyId" AS "receiverId",
+      r."name" AS "receiverName",
+      r."logo" AS "receiverLogo",
+      cb."previousOwnerCompanyId" AS "senderId",
+      s."name" AS "senderName",
+      s."logo" AS "senderLogo",
+      CASE
+        WHEN cb."isNotTransferred" = TRUE THEN 'issued'
+        ELSE 'received'
+      END AS "type",
+      cb."cooperativeApproachId" AS "cooperativeApproachId",
+      cb."authorizationPurpose"::text AS "authorizationPurpose",
+      cb."accountType"::text AS "accountType",
+      COALESCE(cb."omgeDeductedAtIssuance", FALSE) AS "omgeDeductedAtIssuance",
+      COALESCE(cb."sopDeductedAtIssuance", FALSE) AS "sopDeductedAtIssuance"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company r ON cb."ownerCompanyId" = r."companyId"
+    LEFT JOIN company s ON cb."previousOwnerCompanyId" = s."companyId"
+    WHERE cb."ownerCompanyId" != 0`);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "VIEW",
+        "credit_block_balances_view_entity",
+        `SELECT
+      cb."creditBlockId" AS "id",
+      cb."serialNumber" AS "serialNumber",
+      cb."itmoSerial" AS "itmoSerial",
+      (cb."creditAmount" - cb."reservedCreditAmount") AS "creditAmount",
+      cb."reservedCreditAmount" AS "reservedCredits",
+      cb."createTime" AS "createdDate",
+      cb."txTime" AS "updatedTime",
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      cb."ownerCompanyId" AS "receiverId",
+      r."name" AS "receiverName",
+      r."logo" AS "receiverLogo",
+      cb."previousOwnerCompanyId" AS "senderId",
+      s."name" AS "senderName",
+      s."logo" AS "senderLogo",
+      CASE
+        WHEN cb."isNotTransferred" = TRUE THEN 'issued'
+        ELSE 'received'
+      END AS "type",
+      cb."cooperativeApproachId" AS "cooperativeApproachId",
+      cb."authorizationPurpose"::text AS "authorizationPurpose",
+      cb."accountType"::text AS "accountType",
+      COALESCE(cb."omgeDeductedAtIssuance", FALSE) AS "omgeDeductedAtIssuance",
+      COALESCE(cb."sopDeductedAtIssuance", FALSE) AS "sopDeductedAtIssuance"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company r ON cb."ownerCompanyId" = r."companyId"
+    LEFT JOIN company s ON cb."previousOwnerCompanyId" = s."companyId"
+    WHERE cb."ownerCompanyId" != 0`,
+      ]
+    );
+
+    // --- credit_block_org_balances_view_entity (Balance -> By Organization) ---
+    await queryRunner.query(`CREATE VIEW "credit_block_org_balances_view_entity" AS
+    SELECT
+      cb."ownerCompanyId" AS "organizationId",
+      o."name" AS "organizationName",
+      o."logo" AS "organizationLogo",
+      SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance",
+      SUM(cb."reservedCreditAmount") AS "reservedCredits",
+      MAX(cb."txTime") AS "updatedTime"
+    FROM credit_blocks_entity cb
+    LEFT JOIN company o ON cb."ownerCompanyId" = o."companyId"
+    WHERE cb."ownerCompanyId" != 0
+    GROUP BY cb."ownerCompanyId", o."name", o."logo"`);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "VIEW",
+        "credit_block_org_balances_view_entity",
+        `SELECT
+      cb."ownerCompanyId" AS "organizationId",
+      o."name" AS "organizationName",
+      o."logo" AS "organizationLogo",
+      SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance",
+      SUM(cb."reservedCreditAmount") AS "reservedCredits",
+      MAX(cb."txTime") AS "updatedTime"
+    FROM credit_blocks_entity cb
+    LEFT JOIN company o ON cb."ownerCompanyId" = o."companyId"
+    WHERE cb."ownerCompanyId" != 0
+    GROUP BY cb."ownerCompanyId", o."name", o."logo"`,
+      ]
+    );
+
+    // --- credit_block_project_balances_view_entity (Balance -> By Project, DNA) ---
+    await queryRunner.query(`CREATE VIEW "credit_block_project_balances_view_entity" AS
+    SELECT
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      p."companyId" AS "projectOwnerId",
+      pc."name" AS "projectOwnerName",
+      pc."logo" AS "projectOwnerLogo",
+      SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance",
+      SUM(cb."reservedCreditAmount") AS "reservedCredits",
+      MAX(cb."txTime") AS "updatedTime"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company pc ON p."companyId" = pc."companyId"
+    WHERE cb."ownerCompanyId" != 0
+    GROUP BY cb."projectRefId", p."title", p."companyId", pc."name", pc."logo"`);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "VIEW",
+        "credit_block_project_balances_view_entity",
+        `SELECT
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      p."companyId" AS "projectOwnerId",
+      pc."name" AS "projectOwnerName",
+      pc."logo" AS "projectOwnerLogo",
+      SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance",
+      SUM(cb."reservedCreditAmount") AS "reservedCredits",
+      MAX(cb."txTime") AS "updatedTime"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company pc ON p."companyId" = pc."companyId"
+    WHERE cb."ownerCompanyId" != 0
+    GROUP BY cb."projectRefId", p."title", p."companyId", pc."name", pc."logo"`,
+      ]
+    );
+
+    // --- credit_block_project_holder_balances_view_entity (Balance -> By Project, Project Developer) ---
+    await queryRunner.query(`CREATE VIEW "credit_block_project_holder_balances_view_entity" AS
+    SELECT
+      cb."projectRefId" || '-' || cb."ownerCompanyId" AS "id",
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      p."companyId" AS "projectOwnerId",
+      pc."name" AS "projectOwnerName",
+      pc."logo" AS "projectOwnerLogo",
+      cb."ownerCompanyId" AS "holderId",
+      SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance",
+      SUM(cb."reservedCreditAmount") AS "reservedCredits",
+      MAX(cb."txTime") AS "updatedTime"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company pc ON p."companyId" = pc."companyId"
+    WHERE cb."ownerCompanyId" != 0
+    GROUP BY cb."projectRefId", p."title", p."companyId", pc."name", pc."logo", cb."ownerCompanyId"`);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "VIEW",
+        "credit_block_project_holder_balances_view_entity",
+        `SELECT
+      cb."projectRefId" || '-' || cb."ownerCompanyId" AS "id",
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      p."companyId" AS "projectOwnerId",
+      pc."name" AS "projectOwnerName",
+      pc."logo" AS "projectOwnerLogo",
+      cb."ownerCompanyId" AS "holderId",
+      SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance",
+      SUM(cb."reservedCreditAmount") AS "reservedCredits",
+      MAX(cb."txTime") AS "updatedTime"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company pc ON p."companyId" = pc."companyId"
+    WHERE cb."ownerCompanyId" != 0
+    GROUP BY cb."projectRefId", p."title", p."companyId", pc."name", pc."logo", cb."ownerCompanyId"`,
+      ]
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // --- drop the 3 new views, newest first ---
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["VIEW", "credit_block_project_holder_balances_view_entity", "public"]
+    );
+    await queryRunner.query(
+      `DROP VIEW "credit_block_project_holder_balances_view_entity"`
+    );
+
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["VIEW", "credit_block_project_balances_view_entity", "public"]
+    );
+    await queryRunner.query(
+      `DROP VIEW "credit_block_project_balances_view_entity"`
+    );
+
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["VIEW", "credit_block_org_balances_view_entity", "public"]
+    );
+    await queryRunner.query(`DROP VIEW "credit_block_org_balances_view_entity"`);
+
+    // --- restore the original (pre-extension) credit_block_balances_view_entity ---
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["VIEW", "credit_block_balances_view_entity", "public"]
+    );
+    await queryRunner.query(`DROP VIEW "credit_block_balances_view_entity"`);
+
+    await queryRunner.query(`CREATE VIEW "credit_block_balances_view_entity" AS
+    SELECT
+      cb."creditBlockId" AS "id",
+      cb."serialNumber" AS "serialNumber",
+      cb."itmoSerial" AS "itmoSerial",
+      (cb."creditAmount" - cb."reservedCreditAmount") AS "creditAmount",
+      cb."createTime" AS "createdDate",
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      cb."ownerCompanyId" AS "receiverId",
+      r."name" AS "receiverName",
+      r."logo" AS "receiverLogo",
+      cb."previousOwnerCompanyId" AS "senderId",
+      s."name" AS "senderName",
+      s."logo" AS "senderLogo",
+      CASE
+        WHEN cb."isNotTransferred" = TRUE THEN 'issued'
+        ELSE 'received'
+      END AS "type",
+      cb."cooperativeApproachId" AS "cooperativeApproachId",
+      cb."authorizationPurpose"::text AS "authorizationPurpose",
+      cb."accountType"::text AS "accountType",
+      COALESCE(cb."omgeDeductedAtIssuance", FALSE) AS "omgeDeductedAtIssuance",
+      COALESCE(cb."sopDeductedAtIssuance", FALSE) AS "sopDeductedAtIssuance"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company r ON cb."ownerCompanyId" = r."companyId"
+    LEFT JOIN company s ON cb."previousOwnerCompanyId" = s."companyId"
+    WHERE cb."ownerCompanyId" != 0`);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "VIEW",
+        "credit_block_balances_view_entity",
+        `SELECT
+      cb."creditBlockId" AS "id",
+      cb."serialNumber" AS "serialNumber",
+      cb."itmoSerial" AS "itmoSerial",
+      (cb."creditAmount" - cb."reservedCreditAmount") AS "creditAmount",
+      cb."createTime" AS "createdDate",
+      cb."projectRefId" AS "projectId",
+      p."title" AS "projectName",
+      cb."ownerCompanyId" AS "receiverId",
+      r."name" AS "receiverName",
+      r."logo" AS "receiverLogo",
+      cb."previousOwnerCompanyId" AS "senderId",
+      s."name" AS "senderName",
+      s."logo" AS "senderLogo",
+      CASE
+        WHEN cb."isNotTransferred" = TRUE THEN 'issued'
+        ELSE 'received'
+      END AS "type",
+      cb."cooperativeApproachId" AS "cooperativeApproachId",
+      cb."authorizationPurpose"::text AS "authorizationPurpose",
+      cb."accountType"::text AS "accountType",
+      COALESCE(cb."omgeDeductedAtIssuance", FALSE) AS "omgeDeductedAtIssuance",
+      COALESCE(cb."sopDeductedAtIssuance", FALSE) AS "sopDeductedAtIssuance"
+    FROM credit_blocks_entity cb
+    LEFT JOIN project_entity p ON cb."projectRefId" = p."refId"
+    LEFT JOIN company r ON cb."ownerCompanyId" = r."companyId"
+    LEFT JOIN company s ON cb."previousOwnerCompanyId" = s."companyId"
+    WHERE cb."ownerCompanyId" != 0`,
+      ]
+    );
+  }
+}

--- a/backend/services/src/national-api/credit.transactions.management.controller.ts
+++ b/backend/services/src/national-api/credit.transactions.management.controller.ts
@@ -83,6 +83,40 @@ export class CreditTransactionsManagementController {
   @CheckPolicies((ability: AppAbility) =>
     ability.can(Action.Read, ProjectEntity)
   )
+  @Post("queryBalanceByOrganization")
+  async queryBalanceByOrganization(
+    @Body() queryDto: QueryDto,
+    @Request() req
+  ): Promise<any> {
+    return this.creditTransactionsManagementService.queryBalanceByOrganization(
+      queryDto,
+      req.abilityCondition,
+      req.user
+    );
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, PoliciesGuard)
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, ProjectEntity)
+  )
+  @Post("queryBalanceByProject")
+  async queryBalanceByProject(
+    @Body() queryDto: QueryDto,
+    @Request() req
+  ): Promise<any> {
+    return this.creditTransactionsManagementService.queryBalanceByProject(
+      queryDto,
+      req.abilityCondition,
+      req.user
+    );
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, PoliciesGuard)
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, ProjectEntity)
+  )
   @Post("queryTransfers")
   async queryTransfers(
     @Body() queryDto: QueryDto,


### PR DESCRIPTION
 ## What this does

  Adds two new ways to look at credit balances in the registry: a **By Organization**
  view and a **By Project** view. Until now, the Balance screen could only show credits
  block-by-block. That's fine when you're chasing a specific serial number, but it's not
  much help when someone asks "how many live credits does this organization actually
  hold?" or "what's the standing balance on this project?"

  These two endpoints answer exactly those questions, with the totals pre-aggregated in
  the database so the frontend just renders rows.

  ## The new endpoints

  Both are `POST` endpoints on the credit transactions controller and take the standard
  `QueryDto` (filter / sort / paginate), so they behave like every other list endpoint
  in the app.

  - `POST /national/creditTransactions/queryBalanceByOrganization`
    One row per credit-holding organization: its balance, its reserved credits, and when
    it was last touched.

  - `POST /national/creditTransactions/queryBalanceByProject`
    One row per project: the project's standing balance and reserved credits, plus who
    developed it.

  ## Who sees what

  The balance you see depends on your role — this is baked into which view backs the
  query, not bolted on afterwards:

  - **By Organization** is **DNA-only**. It's a registry-wide roll-up across every
    organization, so anyone who isn't the Designated National Authority gets a `400`.
  - **By Project** is available to **DNA and Project Developers**, but they see different
    numbers:
    - **DNA** sees the full project total, summed across *every* organization holding
      credits in that project.
    - **A Project Developer** sees the same list of projects but scoped strictly to the
      credits *their own company* holds. That scoping happens at the view's grain (a
      `holderId = own companyId` filter on a per-holder view), so a PD can never see
      another holder's balances even by fiddling with filters.
    - **Independent Certifiers** are blocked from this endpoint (`400`).

  ## How it's built

  Three new read-side views under `view-entities/`, following the same pattern as the
  existing credit views:

  - `credit_block_org_balances_view_entity` — balance per owning organization.
  - `credit_block_project_balances_view_entity` — balance per project, summed across all
    holders (DNA).
  - `credit_block_project_holder_balances_view_entity` — balance per (project, holder)
    pair, so a PD's own holdings come out as one row per project (Project Developer).

  All three aggregate `creditAmount - reservedCreditAmount` for the live balance and sum
  `reservedCreditAmount` separately, over non-retired blocks only (`ownerCompanyId != 0`).
  A couple of deliberate choices worth calling out:

  - **Account type is ignored on purpose.** These totals always cover all account types —
    the page's account-type filter doesn't narrow them.
  - **`projectOwner*` always means the project's *developer*** (`project_entity.companyId`),
    which can be a different company from whoever currently holds the credits.

  I also extended the existing `credit_block_balances_view_entity` with `reservedCredits`
  and `updatedTime`, so the per-block "expanded" table under each project row has the
  fields the design needs.

  ## Migration

  `1784870412942-CreditBalanceAggregationViews.ts` creates the three new views and
  rebuilds `credit_block_balances_view_entity` with the two extra columns (with a matching
  `down` that restores the original).

  Heads up: this one was **hand-written rather than `migration:generate`d**. The local dev
  DB runs with `synchronize=true`, so it had already auto-synced these exact views and the
  generator had nothing left to diff (it just surfaced unrelated pre-existing drift). The
  `CREATE VIEW` SQL is copied verbatim from each view-entity's `expression`, matching the
  convention set by the earlier `AddCreditBlockIssuancesView` migration.