### PR TITLE
feat(web): add native year filter control to FilterBar

### DIFF
--- a/web/src/Components/Common/FilterBar/FilterBar.scss
+++ b/web/src/Components/Common/FilterBar/FilterBar.scss
@@ -112,18 +112,17 @@
   &__radio-group--expanded &__overflow-row { order: 2; }
   &__radio-measure { position: absolute; visibility: hidden; pointer-events: none; white-space: nowrap; width: max-content; }
   &__controls { justify-content: flex-end; flex: 1 1 360px; }
-  &__control_extra {
-    .ant-picker {
-      height: 32px !important;
-      border-radius: 6px !important;
-    }
-    .ant-picker-focused:not(:focus-within) {
-      box-shadow: none !important;
-      border-color: #d9d9d9 !important;
-    }
-  }
   &__control { gap: 8px; min-width: 210px; }
-  &__control .ant-select, &__control .ant-input-search { width: 100%; }
+  &__control--year { min-width: auto; }
+  &__control .ant-select, &__control .ant-input-search, &__control .ant-picker { width: 100%; }
+  &__control .ant-picker {
+    height: 32px !important;
+    border-radius: 6px !important;
+  }
+  &__control .ant-picker-focused:not(:focus-within) {
+    box-shadow: none !important;
+    border-color: #d9d9d9 !important;
+  }
   &__control .ant-input-search > .ant-input-group > .ant-input-affix-wrapper {
     border-radius: 6px 0 0 6px !important;
   }

--- a/web/src/Components/Common/FilterBar/FilterBar.tsx
+++ b/web/src/Components/Common/FilterBar/FilterBar.tsx
@@ -1,6 +1,7 @@
-import { Button, Checkbox, Empty, Input, Popover, Radio, Select, Skeleton, Spin, Tag } from "antd";
+import { Button, Checkbox, DatePicker, Empty, Input, Popover, Radio, Select, Skeleton, Spin, Tag } from "antd";
 import { DoubleRightOutlined, InfoCircleOutlined } from "@ant-design/icons";
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import moment from "moment";
 import "./FilterBar.scss";
 
 const { Search } = Input;
@@ -70,15 +71,25 @@ export interface MultiSelectFilterControl extends ControlBase, AsyncSelectContro
   onChange?: (value: FilterValue[]) => void;
 }
 
+/** A single year picker (e.g. credit vintage) — stores the picked year as a
+ * plain number in `values`, same as a select control's value. */
+export interface YearFilterControl extends ControlBase {
+  type: "year";
+  clearValue?: FilterValue;
+  onChange?: (value: FilterValue | undefined) => void;
+}
+
 export type FilterControl =
   | SearchFilterControl
   | SingleSelectFilterControl
-  | MultiSelectFilterControl;
+  | MultiSelectFilterControl
+  | YearFilterControl;
 
 type ResolvedFilterControl =
   | (SearchFilterControl & { value: string })
   | (SingleSelectFilterControl & { value?: FilterValue })
-  | (MultiSelectFilterControl & { value: FilterValue[] });
+  | (MultiSelectFilterControl & { value: FilterValue[] })
+  | (YearFilterControl & { value?: FilterValue });
 
 export interface RadioFilterGroup {
   id: string;
@@ -100,17 +111,6 @@ export interface RadioFilterGroup {
 export interface FilterBarProps {
   radioGroup?: RadioFilterGroup;
   controls?: FilterControl[];
-  /** Rendered as one more item alongside `controls`, in the same row and
-   * gap, for a control shape the FilterControl union doesn't model (e.g. a
-   * year picker). Not tracked by `values`/applied-chips - the caller owns
-   * its own state and applied indicator, if any. */
-  extraControls?: ReactNode;
-  /** Applied-filter chips for `extraControls` - since that state lives
-   * outside `values`, the caller supplies its own chip(s) and remove
-   * handler(s) directly instead of FilterBar deriving them. Also cleared by
-   * "Clear All" alongside `onClearAll` (the caller's `onClearAll` should
-   * reset this state too - FilterBar only renders the chips/click-off). */
-  extraAppliedChips?: { key: string; label: ReactNode; onRemove: () => void }[];
   values: FilterValues;
   appliedValues?: FilterValues;
   onChange: (id: string, value: FilterControlValue) => void;
@@ -137,8 +137,6 @@ const optionLabel = (options: FilterOption[], value: FilterValue) =>
 export const FilterBar = ({
   radioGroup,
   controls = [],
-  extraControls,
-  extraAppliedChips = [],
   values,
   appliedValues = {},
   onChange,
@@ -166,6 +164,9 @@ export const FilterBar = ({
       const value = values[control.id];
       if (control.type === "search") {
         return { ...control, value: String(value ?? "") };
+      }
+      if (control.type === "year") {
+        return { ...control, value: Array.isArray(value) ? undefined : value };
       }
       if (control.mode === "multiple") {
         return { ...control, value: Array.isArray(value) ? value : [] };
@@ -233,6 +234,18 @@ export const FilterBar = ({
           control.onSearch?.(clearValue);
         },
       });
+    } else if (control.type === "year") {
+      if (control.value !== undefined) {
+        chips.push({
+          key: `${control.id}-${control.value}`,
+          label: control.label ? <>{control.label}: {control.value}</> : <>{control.value}</>,
+          remove: () => emitChange(
+            control.id,
+            control.clearValue,
+            control.onChange as ((value: never) => void) | undefined
+          ),
+        });
+      }
     } else if (control.mode === "multiple") {
       (control.value as FilterValue[]).forEach((value) => chips.push({
         key: `${control.id}-${value}`,
@@ -257,12 +270,6 @@ export const FilterBar = ({
       });
     }
   });
-
-  extraAppliedChips.forEach((chip) => chips.push({
-    key: `extra-${chip.key}`,
-    label: chip.label,
-    remove: chip.onRemove,
-  }));
 
   const rootClassName = ["filter-bar", `filter-bar--${theme}`, disabled ? "filter-bar--disabled" : "", className]
     .filter(Boolean)
@@ -413,7 +420,7 @@ export const FilterBar = ({
     return <div className={rootClassName}><Skeleton active paragraph={{ rows: 1 }} title={false} /></div>;
   }
 
-  if (!visibleRadio && visibleControls.length === 0 && !extraControls) {
+  if (!visibleRadio && visibleControls.length === 0) {
     return <div className={rootClassName}><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={emptyText} /></div>;
   }
 
@@ -525,10 +532,10 @@ export const FilterBar = ({
             </div>
           </div>
         )}
-        <div className={`filter-bar__controls${extraControls ? " filter-bar__control_extra" : ""}`}>
+        <div className="filter-bar__controls">
           {visibleControls.map((control) => (
             <div
-              className={`filter-bar__control${control.type === "search" ? " filter-bar__control--search" : ""}`}
+              className={`filter-bar__control${control.type === "search" ? " filter-bar__control--search" : ""}${control.type === "year" ? " filter-bar__control--year" : ""}`}
               key={control.id}
               style={control.type === "search"
                 ? { flex: "0 0 auto" }
@@ -570,6 +577,20 @@ export const FilterBar = ({
                     }}
                   />
                 </>
+              ) : control.type === "year" ? (
+                <DatePicker
+                  picker="year"
+                  allowClear
+                  value={control.value !== undefined ? moment().year(control.value as number) : null}
+                  placeholder={control.placeholder}
+                  disabled={disabled || control.disabled}
+                  style={control.width ? { width: control.width } : undefined}
+                  onChange={(date) => emitChange(
+                    control.id,
+                    date ? date.year() : undefined,
+                    control.onChange as ((value: never) => void) | undefined
+                  )}
+                />
               ) : (
                 <Select
                   allowClear
@@ -605,7 +626,6 @@ export const FilterBar = ({
               )}
             </div>
           ))}
-          {extraControls}
         </div>
       </div>
       {showAppliedFilters && chips.length > 0 && (

--- a/web/src/Pages/CreditPages/Components/creditIssuanceTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditIssuanceTable.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   Col,
-  DatePicker,
   Empty,
   message,
   PaginationProps,
@@ -83,6 +82,7 @@ const creditBlockIdFromSerial = (serialNumber: string): string =>
 const INITIAL_FILTER_VALUES: FilterValues = {
   organization: [],
   project: [],
+  vintage: undefined,
 };
 
 interface CreditIssuanceTableProps {
@@ -105,7 +105,6 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
   const [historyLoading, setHistoryLoading] = useState<boolean>(false);
   const [historyEntries, setHistoryEntries] = useState<CreditHistoryEntry[]>([]);
   const [filterValues, setFilterValues] = useState<FilterValues>(INITIAL_FILTER_VALUES);
-  const [vintageYear, setVintageYear] = useState<number>();
 
   // Org & Project dropdowns load lazily, page-by-page, and search server-side
   // (see usePaginatedSelectOptions) rather than preloading the whole list.
@@ -149,6 +148,7 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
       if (projectIds.length > 0) {
         filterAnd.push({ key: "projectId", operation: "in", value: projectIds });
       }
+      const vintageYear = filterValues.vintage as number | undefined;
       if (vintageYear !== undefined) {
         filterAnd.push({
           key: "vintageRange",
@@ -344,11 +344,11 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
         getQueryData();
       }
     }
-  }, [sortField, sortOrder, filterValues.organization, filterValues.project, vintageYear]);
+  }, [sortField, sortOrder, filterValues.organization, filterValues.project, filterValues.vintage]);
 
   return (
     <div className="content-card">
-      <FilterBar 
+      <FilterBar
         controls={[
           {
             id: "organization",
@@ -377,33 +377,16 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
             onPopupScroll: projectSelect.onPopupScroll,
             onDropdownVisibleChange: (open) => open && projectSelect.onDropdownOpen(),
           },
+          {
+            id: "vintage",
+            type: "year",
+            placeholder: t("filterByVintage"),
+            width: 150,
+          },
         ]}
-        extraControls={
-          <div className="filter-bar__control_extra">
-            <DatePicker
-              picker="year"
-              allowClear
-              placeholder={t("filterByVintage")}
-              value={vintageYear !== undefined ? moment().year(vintageYear) : null}
-              onChange={(date) => setVintageYear(date ? date.year() : undefined)}
-            />
-          </div>
-        }
-        extraAppliedChips={
-          vintageYear !== undefined
-            ? [{
-                key: "vintage",
-                label: <>{vintageYear}</>,
-                onRemove: () => setVintageYear(undefined),
-              }]
-            : []
-        }
         values={filterValues}
         onChange={(id, value) => setFilterValues((prev) => ({ ...prev, [id]: value }))}
-        onClearAll={() => {
-          setFilterValues(INITIAL_FILTER_VALUES);
-          setVintageYear(undefined);
-        }}
+        onClearAll={() => setFilterValues(INITIAL_FILTER_VALUES)}
         disabled={loading}
         appliedFiltersLabel={t("appliedFilters")}
         clearAllLabel={t("clearAll")}


### PR DESCRIPTION
Add a `year` control type to the shared FilterBar component, rendered as an antd year DatePicker alongside the search/select controls and tracked through the same values/onChange/applied-chip flow. Remove the extraControls/extraAppliedChips escape hatch it replaces, since the credit vintage picker was its only user.

Wire the Credit Issuance table's vintage filter through the new control instead of a bolted-on DatePicker outside the FilterBar.