### PR TITLE
feat(web,backend): add creditReceived, align profile cards

### DIFF
--- a/backend/services/libs/shared/src/company/company.service.ts
+++ b/backend/services/libs/shared/src/company/company.service.ts
@@ -645,11 +645,11 @@ export class CompanyService {
     );
   }
 
-  // Attaches the per-org credit totals (issued / retired / transferred /
-  // reserved / balance) from CreditBlockOrgAggregationViewEntity onto each
-  // company, so the View Organisations table (creditIssued / creditRetired)
-  // and the profile summary card can read them off the response. Orgs with no
-  // credit activity default to 0.
+  // Attaches the per-org credit totals (issued / received / retired /
+  // transferred / reserved / balance) from CreditBlockOrgAggregationViewEntity
+  // onto each company, so the View Organisations table (creditIssued /
+  // creditRetired) and the profile summary card can read them off the
+  // response. Orgs with no credit activity default to 0.
   private async attachCreditAggregation(companies: Company[]): Promise<void> {
     if (!companies || companies.length === 0) {
       return;
@@ -665,6 +665,7 @@ export class CompanyService {
     for (const company of companies) {
       const agg = byOrgId.get(Number(company.companyId));
       (company as any).creditIssued = Number(agg?.creditIssued ?? 0);
+      (company as any).creditReceived = Number(agg?.creditReceived ?? 0);
       (company as any).creditRetired = Number(agg?.creditRetired ?? 0);
       (company as any).creditTransferred = Number(agg?.creditTransferred ?? 0);
       (company as any).creditReserved = Number(agg?.creditReserved ?? 0);

--- a/backend/services/libs/shared/src/view-entities/credit.block.org.aggregation.view.entity.ts
+++ b/backend/services/libs/shared/src/view-entities/credit.block.org.aggregation.view.entity.ts
@@ -7,6 +7,7 @@ import { ViewColumn, ViewEntity } from "typeorm";
 //   - creditIssued      = SUM(amount) of Issued txns received (recieverId)
 //   - creditRetired     = SUM(amount) of Retired txns performed (senderId)
 //   - creditTransferred = SUM(amount) of Transfered/FirstTransfer txns sent (senderId)
+//   - creditReceived    = SUM(amount) of Transfered/FirstTransfer txns received (recieverId)
 //   - creditReserved    = SUM(reservedCreditAmount) of currently-owned blocks
 //   - creditBalance     = SUM(creditAmount - reservedCreditAmount) of currently-owned blocks
 @ViewEntity({
@@ -16,6 +17,7 @@ import { ViewColumn, ViewEntity } from "typeorm";
       COALESCE(iss."creditIssued", 0) AS "creditIssued",
       COALESCE(ret."creditRetired", 0) AS "creditRetired",
       COALESCE(tr."creditTransferred", 0) AS "creditTransferred",
+      COALESCE(rec."creditReceived", 0) AS "creditReceived",
       COALESCE(bal."creditReserved", 0) AS "creditReserved",
       COALESCE(bal."creditBalance", 0) AS "creditBalance"
     FROM "company" c
@@ -39,6 +41,12 @@ import { ViewColumn, ViewEntity } from "typeorm";
       GROUP BY ct."senderId"
     ) tr ON tr."organizationId" = c."companyId"
     LEFT JOIN (
+      SELECT ct."recieverId" AS "organizationId", SUM(ct."amount") AS "creditReceived"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+      GROUP BY ct."recieverId"
+    ) rec ON rec."organizationId" = c."companyId"
+    LEFT JOIN (
       SELECT
         cb."ownerCompanyId" AS "organizationId",
         SUM(cb."reservedCreditAmount") AS "creditReserved",
@@ -60,6 +68,9 @@ export class CreditBlockOrgAggregationViewEntity {
 
   @ViewColumn()
   creditTransferred: number;
+
+  @ViewColumn()
+  creditReceived: number;
 
   @ViewColumn()
   creditReserved: number;

--- a/backend/services/src/migrations/1785300000000-AddOrgCreditReceived.ts
+++ b/backend/services/src/migrations/1785300000000-AddOrgCreditReceived.ts
@@ -1,0 +1,131 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// Adds creditReceived to credit_block_org_aggregation_view_entity -
+// SUM(amount) of Transfered/FirstTransfer txns received (recieverId), the
+// aggregation counterpart of the org transactions feed's existing
+// "Received" rows. Written as a new migration rather than editing
+// 1785200000000-ExcludePendingFromOrgCreditRetired.ts in place - that
+// migration is already merged into develop (and so has already run against
+// its test database), so TypeORM would just skip a re-edited version of it
+// there; only a new migration actually reaches an environment that's
+// already applied it.
+const ORG_AGGREGATION_VIEW = "credit_block_org_aggregation_view_entity";
+
+const ORG_AGGREGATION_SQL = `
+    SELECT
+      c."companyId" AS "organizationId",
+      COALESCE(iss."creditIssued", 0) AS "creditIssued",
+      COALESCE(ret."creditRetired", 0) AS "creditRetired",
+      COALESCE(tr."creditTransferred", 0) AS "creditTransferred",
+      COALESCE(rec."creditReceived", 0) AS "creditReceived",
+      COALESCE(bal."creditReserved", 0) AS "creditReserved",
+      COALESCE(bal."creditBalance", 0) AS "creditBalance"
+    FROM "company" c
+    LEFT JOIN (
+      SELECT ct."recieverId" AS "organizationId", SUM(ct."amount") AS "creditIssued"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" = 'Issued'
+      GROUP BY ct."recieverId"
+    ) iss ON iss."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT ct."senderId" AS "organizationId", SUM(ct."amount") AS "creditRetired"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" = 'Retired'
+      AND ct.status != 'Pending'
+      GROUP BY ct."senderId"
+    ) ret ON ret."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT ct."senderId" AS "organizationId", SUM(ct."amount") AS "creditTransferred"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+      GROUP BY ct."senderId"
+    ) tr ON tr."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT ct."recieverId" AS "organizationId", SUM(ct."amount") AS "creditReceived"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+      GROUP BY ct."recieverId"
+    ) rec ON rec."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT
+        cb."ownerCompanyId" AS "organizationId",
+        SUM(cb."reservedCreditAmount") AS "creditReserved",
+        SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance"
+      FROM "credit_blocks_entity" cb
+      WHERE cb."ownerCompanyId" != 0
+      GROUP BY cb."ownerCompanyId"
+    ) bal ON bal."organizationId" = c."companyId"`;
+
+const ORG_AGGREGATION_SQL_OLD = `
+    SELECT
+      c."companyId" AS "organizationId",
+      COALESCE(iss."creditIssued", 0) AS "creditIssued",
+      COALESCE(ret."creditRetired", 0) AS "creditRetired",
+      COALESCE(tr."creditTransferred", 0) AS "creditTransferred",
+      COALESCE(bal."creditReserved", 0) AS "creditReserved",
+      COALESCE(bal."creditBalance", 0) AS "creditBalance"
+    FROM "company" c
+    LEFT JOIN (
+      SELECT ct."recieverId" AS "organizationId", SUM(ct."amount") AS "creditIssued"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" = 'Issued'
+      GROUP BY ct."recieverId"
+    ) iss ON iss."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT ct."senderId" AS "organizationId", SUM(ct."amount") AS "creditRetired"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" = 'Retired'
+      AND ct.status != 'Pending'
+      GROUP BY ct."senderId"
+    ) ret ON ret."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT ct."senderId" AS "organizationId", SUM(ct."amount") AS "creditTransferred"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+      GROUP BY ct."senderId"
+    ) tr ON tr."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT
+        cb."ownerCompanyId" AS "organizationId",
+        SUM(cb."reservedCreditAmount") AS "creditReserved",
+        SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance"
+      FROM "credit_blocks_entity" cb
+      WHERE cb."ownerCompanyId" != 0
+      GROUP BY cb."ownerCompanyId"
+    ) bal ON bal."organizationId" = c."companyId"`;
+
+export class AddOrgCreditReceived1785300000000 implements MigrationInterface {
+  name = "AddOrgCreditReceived1785300000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["VIEW", ORG_AGGREGATION_VIEW, "public"]
+    );
+    await queryRunner.query(`DROP VIEW "${ORG_AGGREGATION_VIEW}"`);
+
+    await queryRunner.query(
+      `CREATE VIEW "${ORG_AGGREGATION_VIEW}" AS ${ORG_AGGREGATION_SQL}`
+    );
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      ["public", "VIEW", ORG_AGGREGATION_VIEW, ORG_AGGREGATION_SQL]
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["VIEW", ORG_AGGREGATION_VIEW, "public"]
+    );
+    await queryRunner.query(`DROP VIEW "${ORG_AGGREGATION_VIEW}"`);
+
+    await queryRunner.query(
+      `CREATE VIEW "${ORG_AGGREGATION_VIEW}" AS ${ORG_AGGREGATION_SQL_OLD}`
+    );
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      ["public", "VIEW", ORG_AGGREGATION_VIEW, ORG_AGGREGATION_SQL_OLD]
+    );
+  }
+}

--- a/web/public/locales/i18n/companyProfile/en.json
+++ b/web/public/locales/i18n/companyProfile/en.json
@@ -20,6 +20,7 @@
     "programmeCount":"Number of Projects",
     "creditSummary": "Credit Summary",
     "creditsIssued": "Credits Issued",
+    "creditsReceived": "Credits Received",
     "creditsRetired": "Credits Retired",
     "creditsTransferred": "Credits Transferred",
     "creditsReserved": "Credits Reserved",

--- a/web/public/locales/i18n/companyProfile/es.json
+++ b/web/public/locales/i18n/companyProfile/es.json
@@ -27,6 +27,7 @@
   "adminPhone": "Teléfono",
   "creditSummary": "Resumen de Créditos",
   "creditsIssued": "Créditos Emitidos",
+  "creditsReceived": "Créditos Recibidos",
   "creditsRetired": "Créditos Retirados",
   "creditsTransferred": "Créditos Transferidos",
   "creditsReserved": "Créditos Reservados",

--- a/web/public/locales/i18n/companyProfile/fr.json
+++ b/web/public/locales/i18n/companyProfile/fr.json
@@ -28,6 +28,7 @@
   "adminPhone": "Téléphone",
   "creditSummary": "Résumé des Crédits",
   "creditsIssued": "Crédits Émis",
+  "creditsReceived": "Crédits Reçus",
   "creditsRetired": "Crédits Retirés",
   "creditsTransferred": "Crédits Transférés",
   "creditsReserved": "Crédits Réservés",

--- a/web/src/Components/Company/CompanyDetails/companyDetailsComponent.scss
+++ b/web/src/Components/Company/CompanyDetails/companyDetailsComponent.scss
@@ -70,5 +70,8 @@
       background-color: white !important;
       outline: auto !important;
     }
+
+    .organisation-details-container {
+      flex: 1 1 auto;
+    }
   }
-  

--- a/web/src/Components/Company/CompanyDetails/companyDetailsComponent.tsx
+++ b/web/src/Components/Company/CompanyDetails/companyDetailsComponent.tsx
@@ -23,7 +23,7 @@ export const CompanyDetailsComponent = (props: any) => {
   };
 
   return (
-    <Card className="card-container">
+    <Card className="card-container organisation-details-container">
       <div className="info-view">
         <div className="title">
           <span className="title-icon">

--- a/web/src/Components/Company/CompanyProfile/companyProfileComponent.scss
+++ b/web/src/Components/Company/CompanyProfile/companyProfileComponent.scss
@@ -18,6 +18,11 @@
       width: 100%;
       border-radius: 10px;
     }
+    .profile-left-col,
+    .profile-right-col {
+      display: flex;
+      flex-direction: column;
+    }
   
     .mg-left-1 {
       margin-left: 1rem;
@@ -75,6 +80,11 @@
   }
   
   .credit-summary-container {
+    // Grows to fill the left column's stretched height (see
+    // .profile-left-col), so its bottom edge lines up with the Organisation
+    // Details card on the right regardless of the profile photo's height.
+    flex: 1 1 auto;
+
     .field-value {
       font-weight: 600;
       text-align: right;
@@ -82,6 +92,10 @@
 
     .credit-issued {
       color: #9155fd;
+    }
+
+    .credit-received {
+      color: #1eb980;
     }
 
     .credit-retired {

--- a/web/src/Components/Company/CompanyProfile/companyProfileComponent.tsx
+++ b/web/src/Components/Company/CompanyProfile/companyProfileComponent.tsx
@@ -459,8 +459,8 @@ export const CompanyProfileComponent = (props: any) => {
       )}
       {companyDetails && (
         <div className="content-body">
-          <Row gutter={16}>
-            <Col md={24} lg={10}>
+          <Row gutter={16} align="stretch">
+            <Col md={24} lg={10} className="profile-left-col">
               <Card className="card-container">
                 <Skeleton loading={isLoading} active>
                   <Row justify="center">
@@ -496,6 +496,18 @@ export const CompanyProfileComponent = (props: any) => {
                         : '-'}
                     </Col>
                   </Row>
+                  <Row className="field">
+                    <Col span={12} className="field-key">
+                      {t('companyProfile:creditsReceived')}
+                    </Col>
+                    <Col span={12} className="field-value credit-received">
+                      {companyDetails.creditReceived !== undefined &&
+                      companyDetails.creditReceived !== null
+                        ? addCommSep(companyDetails.creditReceived)
+                        : '-'}
+                    </Col>
+                  </Row>
+                  <div className="credit-summary-divider" />
                   <Row className="field">
                     <Col span={12} className="field-key">
                       {t('companyProfile:creditsRetired')}
@@ -671,7 +683,7 @@ export const CompanyProfileComponent = (props: any) => {
                 </Card>
               )}
             </Col>
-            <Col md={24} lg={14}>
+            <Col md={24} lg={14} className="profile-right-col">
               <CompanyDetailsComponent
                 t={t}
                 companyDetails={companyDetails}

--- a/web/src/Components/CreditHistoryGraph/BinaryTreeGraphView.tsx
+++ b/web/src/Components/CreditHistoryGraph/BinaryTreeGraphView.tsx
@@ -122,8 +122,13 @@ interface BinaryTreeNodeData {
   pathDelayMs: number;
   /** When false, `onClick` is a no-op and the cursor stays default. */
   interactiveSelection: boolean;
+  /** Whether this node's detail panel is expanded — driven by the shared
+   * `expandedDetailIds` set (per-node eye button, or the toolbar's "all"
+   * master toggle). */
+  showInfo: boolean;
   onClick: () => void;
   onToggle: (e: React.MouseEvent) => void;
+  onToggleDetail: () => void;
 }
 
 const BinaryTreeNode = ({ data }: { data: BinaryTreeNodeData }) => {
@@ -139,13 +144,14 @@ const BinaryTreeNode = ({ data }: { data: BinaryTreeNodeData }) => {
     selected,
     pathDelayMs,
     interactiveSelection,
+    showInfo,
     onClick,
     onToggle,
+    onToggleDetail,
   } = data;
   const noteText = note && note.trim() ? note.trim() : null;
-  // Local display toggle for the eye icon. The expanded height isn't in ELK's
-  // layout, so an open node can overlap the row below — accepted for inline info.
-  const [showInfo, setShowInfo] = useState(false);
+  // The expanded height isn't in ELK's layout, so an open node can overlap
+  // the row below — accepted for inline info.
   // On-path labels already read "{range} | {note}"; off-path labels are bare
   // range, so the eye toggle builds the same text to show it in the same spot.
   const displayLabel = showInfo && !onPath && noteText ? `${range} | ${noteText}` : label;
@@ -182,13 +188,13 @@ const BinaryTreeNode = ({ data }: { data: BinaryTreeNodeData }) => {
       }}
     >
       <Handle type="target" position={Position.Top} style={{ visibility: "hidden" }} />
-      <div style={{ display: "flex", alignItems: "flex-start", gap: 8, minWidth: 0 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
         <span style={{ whiteSpace: "normal", wordBreak: "break-word", minWidth: 0, flex: 1 }}>{displayLabel}</span>
         <button
           className="nodrag nopan"
           onClick={(e) => {
             e.stopPropagation();
-            setShowInfo((v) => !v);
+            onToggleDetail();
           }}
           style={{
             border: "none",
@@ -197,7 +203,6 @@ const BinaryTreeNode = ({ data }: { data: BinaryTreeNodeData }) => {
             display: "flex",
             alignItems: "center",
             flexShrink: 0,
-            marginTop: 2,
             cursor: "pointer",
             color: showInfo ? (selected ? "#fff" : "#0b6dc7") : selected ? "#e6f4ff" : "#94a3b8",
           }}
@@ -287,8 +292,10 @@ export const BinaryTreeGraphView = ({
   fitScope,
   isDefaultStateReady,
   maxZoom,
+  expandedDetailIds,
   onSelectNode,
   onToggleCollapse,
+  onToggleNodeDetail,
 }: GraphViewProps) => {
   const { getNodes, fitBounds } = useReactFlow();
   const storeApi = useStoreApi();
@@ -382,11 +389,24 @@ export const BinaryTreeGraphView = ({
           selected: n.id === selectedId,
           pathDelayMs: n.depth * PATH_STAGGER_MS,
           interactiveSelection,
+          showInfo: expandedDetailIds.has(n.id),
           onClick: interactiveSelection ? () => onSelectNode(n.id) : () => {},
           onToggle: () => onToggleCollapse(n.id),
+          onToggleDetail: () => onToggleNodeDetail(n.id),
         },
       })),
-    [layout, collapsed, pathIds, selectedId, interactiveSelection, showCollapseToggle, onSelectNode, onToggleCollapse]
+    [
+      layout,
+      collapsed,
+      pathIds,
+      selectedId,
+      interactiveSelection,
+      showCollapseToggle,
+      expandedDetailIds,
+      onSelectNode,
+      onToggleCollapse,
+      onToggleNodeDetail,
+    ]
   );
 
   // Per-edge depth lookup, for the highlight cascade timing.

--- a/web/src/Components/CreditHistoryGraph/CreditHistoryGraph.tsx
+++ b/web/src/Components/CreditHistoryGraph/CreditHistoryGraph.tsx
@@ -74,6 +74,10 @@ const GraphShell = ({
   const [mode, setMode] = useState<GraphMode>(defaultMode);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Binary Tree's per-node detail panels — IDs currently expanded. Master
+  // toggle (toolbar eye icon) sets/clears every ID at once; the per-node eye
+  // button toggles just its own ID via `onToggleNodeDetail`.
+  const [expandedDetailIds, setExpandedDetailIds] = useState<Set<string>>(new Set());
   // False until `applyDefaultState` runs — gates the views' initial fit past
   // the first paint, which happens with untouched initial state.
   const [isDefaultStateReady, setIsDefaultStateReady] = useState(false);
@@ -90,6 +94,7 @@ const GraphShell = ({
       (defaultSelection === "none" ? null : findDefaultTarget(r));
     setCollapsed(collapseStrategy === "pathOnly" ? collapseAllExceptPath(r, target) : defaultCollapse(r, target));
     setSelectedId(target ? target.id : null);
+    setExpandedDetailIds(new Set());
     setIsDefaultStateReady(true);
     setIsDefaultState(true);
   };
@@ -129,8 +134,22 @@ const GraphShell = ({
     });
     setIsDefaultState(false);
   };
+  const onToggleNodeDetail = (id: string) => {
+    setExpandedDetailIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
   if (!root) return null;
+
+  const allNodeIds = nodeIndex ? Array.from(nodeIndex.keys()) : [];
+  const allDetailsExpanded =
+    allNodeIds.length > 0 && allNodeIds.every((id) => expandedDetailIds.has(id));
+  const onToggleAllDetails = () =>
+    setExpandedDetailIds(allDetailsExpanded ? new Set() : new Set(allNodeIds));
 
   const viewProps = {
     root,
@@ -143,8 +162,10 @@ const GraphShell = ({
     isDefaultStateReady,
     creditMarkerLabel: highlightCredit !== undefined ? `Credit #${highlightCredit} is located here` : undefined,
     maxZoom,
+    expandedDetailIds,
     onSelectNode,
     onToggleCollapse,
+    onToggleNodeDetail,
   };
 
   return (
@@ -160,6 +181,8 @@ const GraphShell = ({
           showOpenInNewTab={showOpenInNewTab}
           showModeToggle={showModeToggle}
           onResetView={onResetView}
+          showAllDetails={allDetailsExpanded}
+          onToggleAllDetails={onToggleAllDetails}
           viewProps={viewProps}
         />
       </ReactFlowProvider>
@@ -175,6 +198,10 @@ interface GraphToolbarAndViewProps {
   showOpenInNewTab: boolean;
   showModeToggle: boolean;
   onResetView: () => void;
+  /** Whether every node's detail panel is currently expanded (Binary Tree
+   * only) — drives the toolbar eye icon's on/off state. */
+  showAllDetails: boolean;
+  onToggleAllDetails: () => void;
   viewProps: GraphViewProps;
 }
 
@@ -189,6 +216,8 @@ const GraphToolbarAndView = ({
   showOpenInNewTab,
   showModeToggle,
   onResetView,
+  showAllDetails,
+  onToggleAllDetails,
   viewProps,
 }: GraphToolbarAndViewProps) => {
   const { zoomIn, zoomOut, getNodes, fitBounds } = useReactFlow();
@@ -261,6 +290,17 @@ const GraphToolbarAndView = ({
                 <Icon.ArrowCounterclockwise />
               </button>
             </Tooltip>
+            {mode === "binary" && (
+              <Tooltip
+                title={showAllDetails ? "Hide details on all nodes" : "Show details on all nodes"}
+                placement="bottom"
+                overlayClassName="chg-toolbar-tooltip"
+              >
+                <button className="chg-icon-btn" onClick={onToggleAllDetails}>
+                  {showAllDetails ? <Icon.EyeSlashFill /> : <Icon.EyeFill />}
+                </button>
+              </Tooltip>
+            )}
             {showOpenInNewTab && (
               <Tooltip title="Open in new tab" placement="bottom" overlayClassName="chg-toolbar-tooltip">
                 <button className="chg-icon-btn" onClick={onOpenFullView}>

--- a/web/src/Components/CreditHistoryGraph/creditHistoryGraph.types.ts
+++ b/web/src/Components/CreditHistoryGraph/creditHistoryGraph.types.ts
@@ -85,6 +85,11 @@ export interface GraphViewProps {
   /** Caps how far "Fit to screen" zooms in (see `fitGraphToScreen`) — set by
    * the fullscreen tab so a small tree isn't oversized; unset when inline. */
   maxZoom?: number;
+  /** IDs of nodes currently showing their expanded detail panel (Binary Tree's
+   * per-node eye toggle). Unused by Timeline, which has no such panel. */
+  expandedDetailIds: Set<string>;
   onSelectNode: (id: string) => void;
   onToggleCollapse: (id: string) => void;
+  /** Toggles a single node's entry in `expandedDetailIds`. */
+  onToggleNodeDetail: (id: string) => void;
 }


### PR DESCRIPTION
**Credit Received**
- Add creditReceived (SUM of received Transfered/FirstTransfer amounts, keyed by recieverId) to credit_block_org_aggregation_view_entity via a new migration (1785300000000), separate from the already-merged Pending-exclusion migration to avoid re-editing it.
- Surface creditReceived through CompanyService.attachCreditAggregation and the organisation profile's Credit Summary card, between Credits Issued and Credits Retired, with its own divider and accent color.
- Add creditsReceived translations (en/fr/es).

**Organisation Profile card alignment**
- Stretch the profile page's two-column Row so the Credit Summary and Organisation Details cards grow to fill their column, keeping both cards' bottom edges level regardless of whether the profile photo is present (tall) or a small placeholder (short).

**Credit History binary tree detail toggle**
- Add a toolbar eye icon (Binary Tree mode only) that shows/hides every node's detail panel at once, lifting the per-node expand state from local component state into GraphShell alongside collapse/selection.
- Center the per-node eye icon against the label instead of pinning it to the top when the label wraps.