### PR TITLE
add subtable sorting and refine page info button UI

### DIFF
--- a/web/src/Components/Common/TimedPageInfoTitle/TimedPageInfoTitle.scss
+++ b/web/src/Components/Common/TimedPageInfoTitle/TimedPageInfoTitle.scss
@@ -30,25 +30,31 @@
   &::before {
     position: absolute;
     z-index: 0;
-    top: 0;
-    left: -6px;
-    width: calc(var(--timed-page-info-expanded-width, 245px) + 6px);
-    height: 30px;
+    top: 3px;
+    left: 0;
+    width: 24px;
+    height: 24px;
     box-sizing: border-box;
-    border: 1px solid #e6e8ec;
-    border-radius: 5px;
-    background: #fff;
-    box-shadow: 0 2px 8px rgba(16, 24, 40, 0.08);
+    border: 1px solid rgba(variables.$primary-color, 0.12);
+    border-radius: 6px;
+    background: rgba(variables.$primary-color, 0.08);
+    box-shadow: none;
     content: '';
-    opacity: 0;
-    transform: scaleX(0.08);
-    transform-origin: left center;
-    transition: opacity 120ms ease, transform 260ms ease;
+    opacity: 1;
+    transition:
+      top 260ms ease,
+      left 260ms ease,
+      width 340ms cubic-bezier(0.22, 1, 0.36, 1),
+      height 260ms ease,
+      border-radius 260ms ease;
+    will-change: width, height, top, left;
   }
 
   &--expanded::before {
-    opacity: 1;
-    transform: scaleX(1);
+    top: 0;
+    left: -2px;
+    width: calc(var(--timed-page-info-expanded-width, 245px) + 6px);
+    height: 30px;
   }
 
   &__message,
@@ -62,10 +68,10 @@
   &__message {
     box-sizing: border-box;
     top: 0;
-    left: 32px;
+    left: 28px;
     width: max-content;
     height: 30px;
-    color: #3a3541;
+    color: variables.$primary-color;
     font-size: 12.8px;
     font-weight: 400;
     line-height: 20px;
@@ -74,13 +80,14 @@
   }
 
   &__button {
-    inset: 0 auto auto 0;
+    inset: 3px auto auto 0;
     justify-content: center;
     width: 24px;
-    height: 30px;
+    height: 24px;
+    box-sizing: border-box;
     padding: 0;
     border: 0;
-    border-radius: 50%;
+    border-radius: 6px;
     background: transparent;
     color: variables.$primary-color;
     cursor: pointer;
@@ -104,12 +111,14 @@
   &--expanded &__message {
     opacity: 1;
     transform: translateX(0);
+    transition-delay: 120ms;
   }
 
   &--waiting &__message,
   &--collapsed &__message {
     opacity: 0;
     transform: translateX(-10px);
+    transition-delay: 0ms;
   }
 
   &--waiting &__button,

--- a/web/src/Components/Common/TimedPageInfoTitle/TimedPageInfoTitle.tsx
+++ b/web/src/Components/Common/TimedPageInfoTitle/TimedPageInfoTitle.tsx
@@ -30,7 +30,7 @@ export const TimedPageInfoTitle = ({
 
   useLayoutEffect(() => {
     if (!messageRef.current) return;
-    setExpandedWidth(Math.min(Math.ceil(messageRef.current.scrollWidth) + 38, 900));
+    setExpandedWidth(Math.min(Math.ceil(messageRef.current.scrollWidth) + 34, 900));
   }, [description]);
 
   useEffect(() => {
@@ -44,7 +44,12 @@ export const TimedPageInfoTitle = ({
     return () => window.clearTimeout(timer);
   }, [displayCycle, pageInfoState]);
 
-  const showPageInfo = () => {
+  const togglePageInfo = () => {
+    if (pageInfoState === 'expanded') {
+      setPageInfoState('collapsed');
+      return;
+    }
+
     setPageInfoState('expanded');
     setDisplayCycle((current) => current + 1);
   };
@@ -70,7 +75,8 @@ export const TimedPageInfoTitle = ({
           type="button"
           className="timed-page-info__button"
           aria-label={infoButtonLabel}
-          onClick={showPageInfo}
+          aria-expanded={pageInfoState === 'expanded'}
+          onClick={togglePageInfo}
         >
           <InfoCircle />
         </button>

--- a/web/src/Pages/CreditPages/Components/creditBalanceByProjectTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditBalanceByProjectTable.tsx
@@ -138,16 +138,17 @@ const OrganizationCell = ({
 const getSerialColumns = (
   openActions?: (row: CreditSerialBalance) => ReactNode,
 ): ColumnsType<CreditSerialBalance> => [
-  { title: 'Serial Number', dataIndex: 'serialNumber', key: 'serialNumber', align: 'left', width: 280, render: (value) => <span className="credit-balance-serial-number">{value}</span> },
-  { title: 'Organization', key: 'organization', align: 'left', render: (_, row) => <OrganizationCell name={row.organization} color={row.organizationColor} logo={row.organizationLogo} /> },
-  { title: 'Updated Date & Time', dataIndex: 'updatedAt', key: 'updatedAt', align: 'left', width: 180, render: (value) => <span className="credit-balance-detail-date">{value}</span> },
-  { title: 'Credit Balance', dataIndex: 'balance', key: 'balance', align: 'right', render: (value) => <span className="credit-balance-detail-number">{formatCredits(value)}</span> },
-  { title: 'Reserved Credits', dataIndex: 'reserved', key: 'reserved', align: 'right', render: (value) => <span className="credit-balance-detail-number">{formatCredits(value)}</span> },
+  { title: 'Serial Number', dataIndex: 'serialNumber', key: 'serialNumber', align: 'left', width: 280, sorter: (a, b) => a.serialNumber.localeCompare(b.serialNumber), render: (value) => <span className="credit-balance-serial-number">{value}</span> },
+  { title: 'Organization', key: 'organization', align: 'left', sorter: (a, b) => a.organization.localeCompare(b.organization), render: (_, row) => <OrganizationCell name={row.organization} color={row.organizationColor} logo={row.organizationLogo} /> },
+  { title: 'Updated Date & Time', dataIndex: 'updatedAt', key: 'updatedAt', align: 'left', width: 180, sorter: (a, b) => a.updatedAt.localeCompare(b.updatedAt), render: (value) => <span className="credit-balance-detail-date">{value}</span> },
+  { title: 'Credit Balance', dataIndex: 'balance', key: 'balance', align: 'right', sorter: (a, b) => a.balance - b.balance, render: (value) => <span className="credit-balance-detail-number">{formatCredits(value)}</span> },
+  { title: 'Reserved Credits', dataIndex: 'reserved', key: 'reserved', align: 'right', sorter: (a, b) => a.reserved - b.reserved, render: (value) => <span className="credit-balance-detail-number">{formatCredits(value)}</span> },
   {
     title: 'Issue or Received',
     dataIndex: 'type',
     key: 'type',
     align: 'center',
+    sorter: (a, b) => a.type.localeCompare(b.type),
     render: (value: IssuedOrReceivedOptions) => (
       <Tag color={value === IssuedOrReceivedOptions.RECEIVED ? 'success' : 'processing'}>
         {value === IssuedOrReceivedOptions.RECEIVED ? 'Received' : 'Issued'}
@@ -616,6 +617,11 @@ export const CreditBalanceByProjectTable = ({
         loading={loading}
         tableLayout="fixed"
         scroll={{ x: 1050 }}
+        onChange={(_pagination, _filters, _sorter, extra) => {
+          if (extra.action === 'sort' && expandedProjectId) {
+            toggleExpandedProject(expandedProjectId, true);
+          }
+        }}
         expandable={{
           expandedRowRender: (row) => (
             <div className={`credit-balance-detail-panel${collapsingProjectId === row.id ? ' credit-balance-detail-panel--collapsing' : ''}`}>


### PR DESCRIPTION
- sort columns in the credit balance subtable, collapsing it when
  the main table is sorted
- let the page info button toggle closed on click, with refined
  expand/collapse animation and changed the UI of the label as well.