### PR TITLE
fix(web,backend): org credit retired filter, reusable project filter, graph overlay overlap, duplicate table requests

### DIFF
--- a/backend/services/libs/shared/src/view-entities/credit.block.org.aggregation.view.entity.ts
+++ b/backend/services/libs/shared/src/view-entities/credit.block.org.aggregation.view.entity.ts
@@ -31,7 +31,7 @@ import { ViewColumn, ViewEntity } from "typeorm";
       SELECT ct."senderId" AS "organizationId", SUM(ct."amount") AS "creditRetired"
       FROM "credit_transactions_entity" ct
       WHERE ct."type" = 'Retired'
-      AND ct.status != 'Pending'
+      AND ct.status = 'Completed'
       GROUP BY ct."senderId"
     ) ret ON ret."organizationId" = c."companyId"
     LEFT JOIN (

--- a/backend/services/libs/shared/src/view-entities/credit.block.org.transactions.view.entity.ts
+++ b/backend/services/libs/shared/src/view-entities/credit.block.org.transactions.view.entity.ts
@@ -98,7 +98,7 @@ import { ViewColumn, ViewEntity } from "typeorm";
       LEFT JOIN company s ON ct."senderId" = s."companyId"
       LEFT JOIN company r ON ct."recieverId" = r."companyId"
       WHERE ct."type" = 'Retired'
-      AND ct.status != 'Pending'
+      AND ct.status = 'Completed'
     `,
 })
 export class CreditBlockOrgTransactionsViewEntity {

--- a/backend/services/src/migrations/1785400000000-RequireCompletedForOrgCreditRetired.ts
+++ b/backend/services/src/migrations/1785400000000-RequireCompletedForOrgCreditRetired.ts
@@ -1,0 +1,341 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// Forward-fixes the two org-credit views' "Retired" branches again: excluding
+// only status = 'Pending' (1785200000000-ExcludePendingFromOrgCreditRetired.ts)
+// still counted retirements sitting in other non-final states (e.g. Rejected/
+// Cancelled, if such statuses exist on a retirement) as retired. Tightens the
+// filter to require status = 'Completed' explicitly, so only fully-approved
+// retirements count toward creditRetired and the "Retired" rows in the org
+// transactions feed. Written as a new migration rather than editing
+// 1785200000000/1785300000000 in place - those have already run against
+// develop's test database, so TypeORM would just skip re-edited versions of
+// them there; only a new migration actually reaches an environment that's
+// already applied them.
+const ORG_TRANSACTIONS_VIEW = "credit_block_org_transactions_view_entity";
+const ORG_AGGREGATION_VIEW = "credit_block_org_aggregation_view_entity";
+
+const ORG_TRANSACTIONS_SQL = `
+      SELECT
+        ct."id" AS "id",
+        'Issued' AS "currentStatus",
+        ct."recieverId" AS "organizationId",
+        ct."serialNumber" AS "serialNumber",
+        ct."projectRefId" AS "projectId",
+        p."title" AS "projectName",
+        s."name" AS "senderName",
+        s."logo" AS "senderLogo",
+        r."name" AS "receiverName",
+        r."logo" AS "receiverLogo",
+        ct."createTime" AS "updatedDate",
+        ct."amount" AS "creditAmount"
+      FROM "credit_transactions_entity" ct
+      LEFT JOIN project_entity p ON ct."projectRefId" = p."refId"
+      LEFT JOIN company s ON ct."senderId" = s."companyId"
+      LEFT JOIN company r ON ct."recieverId" = r."companyId"
+      WHERE ct."type" = 'Issued'
+
+      UNION ALL
+
+      SELECT
+        ct."id" AS "id",
+        'Received' AS "currentStatus",
+        ct."recieverId" AS "organizationId",
+        ct."serialNumber" AS "serialNumber",
+        ct."projectRefId" AS "projectId",
+        p."title" AS "projectName",
+        s."name" AS "senderName",
+        s."logo" AS "senderLogo",
+        r."name" AS "receiverName",
+        r."logo" AS "receiverLogo",
+        ct."createTime" AS "updatedDate",
+        ct."amount" AS "creditAmount"
+      FROM "credit_transactions_entity" ct
+      LEFT JOIN project_entity p ON ct."projectRefId" = p."refId"
+      LEFT JOIN company s ON ct."senderId" = s."companyId"
+      LEFT JOIN company r ON ct."recieverId" = r."companyId"
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+
+      UNION ALL
+
+      SELECT
+        ct."id" AS "id",
+        'Transferred' AS "currentStatus",
+        ct."senderId" AS "organizationId",
+        ct."serialNumber" AS "serialNumber",
+        ct."projectRefId" AS "projectId",
+        p."title" AS "projectName",
+        s."name" AS "senderName",
+        s."logo" AS "senderLogo",
+        r."name" AS "receiverName",
+        r."logo" AS "receiverLogo",
+        ct."createTime" AS "updatedDate",
+        ct."amount" AS "creditAmount"
+      FROM "credit_transactions_entity" ct
+      LEFT JOIN project_entity p ON ct."projectRefId" = p."refId"
+      LEFT JOIN company s ON ct."senderId" = s."companyId"
+      LEFT JOIN company r ON ct."recieverId" = r."companyId"
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+
+      UNION ALL
+
+      SELECT
+        ct."id" AS "id",
+        'Retired' AS "currentStatus",
+        ct."senderId" AS "organizationId",
+        ct."serialNumber" AS "serialNumber",
+        ct."projectRefId" AS "projectId",
+        p."title" AS "projectName",
+        s."name" AS "senderName",
+        s."logo" AS "senderLogo",
+        r."name" AS "receiverName",
+        r."logo" AS "receiverLogo",
+        ct."createTime" AS "updatedDate",
+        ct."amount" AS "creditAmount"
+      FROM "credit_transactions_entity" ct
+      LEFT JOIN project_entity p ON ct."projectRefId" = p."refId"
+      LEFT JOIN company s ON ct."senderId" = s."companyId"
+      LEFT JOIN company r ON ct."recieverId" = r."companyId"
+      WHERE ct."type" = 'Retired'
+      AND ct.status = 'Completed'
+    `;
+
+const ORG_TRANSACTIONS_SQL_OLD = `
+      SELECT
+        ct."id" AS "id",
+        'Issued' AS "currentStatus",
+        ct."recieverId" AS "organizationId",
+        ct."serialNumber" AS "serialNumber",
+        ct."projectRefId" AS "projectId",
+        p."title" AS "projectName",
+        s."name" AS "senderName",
+        s."logo" AS "senderLogo",
+        r."name" AS "receiverName",
+        r."logo" AS "receiverLogo",
+        ct."createTime" AS "updatedDate",
+        ct."amount" AS "creditAmount"
+      FROM "credit_transactions_entity" ct
+      LEFT JOIN project_entity p ON ct."projectRefId" = p."refId"
+      LEFT JOIN company s ON ct."senderId" = s."companyId"
+      LEFT JOIN company r ON ct."recieverId" = r."companyId"
+      WHERE ct."type" = 'Issued'
+
+      UNION ALL
+
+      SELECT
+        ct."id" AS "id",
+        'Received' AS "currentStatus",
+        ct."recieverId" AS "organizationId",
+        ct."serialNumber" AS "serialNumber",
+        ct."projectRefId" AS "projectId",
+        p."title" AS "projectName",
+        s."name" AS "senderName",
+        s."logo" AS "senderLogo",
+        r."name" AS "receiverName",
+        r."logo" AS "receiverLogo",
+        ct."createTime" AS "updatedDate",
+        ct."amount" AS "creditAmount"
+      FROM "credit_transactions_entity" ct
+      LEFT JOIN project_entity p ON ct."projectRefId" = p."refId"
+      LEFT JOIN company s ON ct."senderId" = s."companyId"
+      LEFT JOIN company r ON ct."recieverId" = r."companyId"
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+
+      UNION ALL
+
+      SELECT
+        ct."id" AS "id",
+        'Transferred' AS "currentStatus",
+        ct."senderId" AS "organizationId",
+        ct."serialNumber" AS "serialNumber",
+        ct."projectRefId" AS "projectId",
+        p."title" AS "projectName",
+        s."name" AS "senderName",
+        s."logo" AS "senderLogo",
+        r."name" AS "receiverName",
+        r."logo" AS "receiverLogo",
+        ct."createTime" AS "updatedDate",
+        ct."amount" AS "creditAmount"
+      FROM "credit_transactions_entity" ct
+      LEFT JOIN project_entity p ON ct."projectRefId" = p."refId"
+      LEFT JOIN company s ON ct."senderId" = s."companyId"
+      LEFT JOIN company r ON ct."recieverId" = r."companyId"
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+
+      UNION ALL
+
+      SELECT
+        ct."id" AS "id",
+        'Retired' AS "currentStatus",
+        ct."senderId" AS "organizationId",
+        ct."serialNumber" AS "serialNumber",
+        ct."projectRefId" AS "projectId",
+        p."title" AS "projectName",
+        s."name" AS "senderName",
+        s."logo" AS "senderLogo",
+        r."name" AS "receiverName",
+        r."logo" AS "receiverLogo",
+        ct."createTime" AS "updatedDate",
+        ct."amount" AS "creditAmount"
+      FROM "credit_transactions_entity" ct
+      LEFT JOIN project_entity p ON ct."projectRefId" = p."refId"
+      LEFT JOIN company s ON ct."senderId" = s."companyId"
+      LEFT JOIN company r ON ct."recieverId" = r."companyId"
+      WHERE ct."type" = 'Retired'
+      AND ct.status != 'Pending'
+    `;
+
+const ORG_AGGREGATION_SQL = `
+    SELECT
+      c."companyId" AS "organizationId",
+      COALESCE(iss."creditIssued", 0) AS "creditIssued",
+      COALESCE(ret."creditRetired", 0) AS "creditRetired",
+      COALESCE(tr."creditTransferred", 0) AS "creditTransferred",
+      COALESCE(rec."creditReceived", 0) AS "creditReceived",
+      COALESCE(bal."creditReserved", 0) AS "creditReserved",
+      COALESCE(bal."creditBalance", 0) AS "creditBalance"
+    FROM "company" c
+    LEFT JOIN (
+      SELECT ct."recieverId" AS "organizationId", SUM(ct."amount") AS "creditIssued"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" = 'Issued'
+      GROUP BY ct."recieverId"
+    ) iss ON iss."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT ct."senderId" AS "organizationId", SUM(ct."amount") AS "creditRetired"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" = 'Retired'
+      AND ct.status = 'Completed'
+      GROUP BY ct."senderId"
+    ) ret ON ret."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT ct."senderId" AS "organizationId", SUM(ct."amount") AS "creditTransferred"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+      GROUP BY ct."senderId"
+    ) tr ON tr."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT ct."recieverId" AS "organizationId", SUM(ct."amount") AS "creditReceived"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+      GROUP BY ct."recieverId"
+    ) rec ON rec."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT
+        cb."ownerCompanyId" AS "organizationId",
+        SUM(cb."reservedCreditAmount") AS "creditReserved",
+        SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance"
+      FROM "credit_blocks_entity" cb
+      WHERE cb."ownerCompanyId" != 0
+      GROUP BY cb."ownerCompanyId"
+    ) bal ON bal."organizationId" = c."companyId"`;
+
+const ORG_AGGREGATION_SQL_OLD = `
+    SELECT
+      c."companyId" AS "organizationId",
+      COALESCE(iss."creditIssued", 0) AS "creditIssued",
+      COALESCE(ret."creditRetired", 0) AS "creditRetired",
+      COALESCE(tr."creditTransferred", 0) AS "creditTransferred",
+      COALESCE(rec."creditReceived", 0) AS "creditReceived",
+      COALESCE(bal."creditReserved", 0) AS "creditReserved",
+      COALESCE(bal."creditBalance", 0) AS "creditBalance"
+    FROM "company" c
+    LEFT JOIN (
+      SELECT ct."recieverId" AS "organizationId", SUM(ct."amount") AS "creditIssued"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" = 'Issued'
+      GROUP BY ct."recieverId"
+    ) iss ON iss."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT ct."senderId" AS "organizationId", SUM(ct."amount") AS "creditRetired"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" = 'Retired'
+      AND ct.status != 'Pending'
+      GROUP BY ct."senderId"
+    ) ret ON ret."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT ct."senderId" AS "organizationId", SUM(ct."amount") AS "creditTransferred"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+      GROUP BY ct."senderId"
+    ) tr ON tr."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT ct."recieverId" AS "organizationId", SUM(ct."amount") AS "creditReceived"
+      FROM "credit_transactions_entity" ct
+      WHERE ct."type" IN ('Transfered', 'FirstTransfer')
+      GROUP BY ct."recieverId"
+    ) rec ON rec."organizationId" = c."companyId"
+    LEFT JOIN (
+      SELECT
+        cb."ownerCompanyId" AS "organizationId",
+        SUM(cb."reservedCreditAmount") AS "creditReserved",
+        SUM(cb."creditAmount" - cb."reservedCreditAmount") AS "creditBalance"
+      FROM "credit_blocks_entity" cb
+      WHERE cb."ownerCompanyId" != 0
+      GROUP BY cb."ownerCompanyId"
+    ) bal ON bal."organizationId" = c."companyId"`;
+
+export class RequireCompletedForOrgCreditRetired1785400000000
+  implements MigrationInterface
+{
+  name = "RequireCompletedForOrgCreditRetired1785400000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["VIEW", ORG_AGGREGATION_VIEW, "public"]
+    );
+    await queryRunner.query(`DROP VIEW "${ORG_AGGREGATION_VIEW}"`);
+
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["VIEW", ORG_TRANSACTIONS_VIEW, "public"]
+    );
+    await queryRunner.query(`DROP VIEW "${ORG_TRANSACTIONS_VIEW}"`);
+
+    await queryRunner.query(
+      `CREATE VIEW "${ORG_TRANSACTIONS_VIEW}" AS ${ORG_TRANSACTIONS_SQL}`
+    );
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      ["public", "VIEW", ORG_TRANSACTIONS_VIEW, ORG_TRANSACTIONS_SQL]
+    );
+
+    await queryRunner.query(
+      `CREATE VIEW "${ORG_AGGREGATION_VIEW}" AS ${ORG_AGGREGATION_SQL}`
+    );
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      ["public", "VIEW", ORG_AGGREGATION_VIEW, ORG_AGGREGATION_SQL]
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["VIEW", ORG_AGGREGATION_VIEW, "public"]
+    );
+    await queryRunner.query(`DROP VIEW "${ORG_AGGREGATION_VIEW}"`);
+
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["VIEW", ORG_TRANSACTIONS_VIEW, "public"]
+    );
+    await queryRunner.query(`DROP VIEW "${ORG_TRANSACTIONS_VIEW}"`);
+
+    await queryRunner.query(
+      `CREATE VIEW "${ORG_TRANSACTIONS_VIEW}" AS ${ORG_TRANSACTIONS_SQL_OLD}`
+    );
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      ["public", "VIEW", ORG_TRANSACTIONS_VIEW, ORG_TRANSACTIONS_SQL_OLD]
+    );
+
+    await queryRunner.query(
+      `CREATE VIEW "${ORG_AGGREGATION_VIEW}" AS ${ORG_AGGREGATION_SQL_OLD}`
+    );
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      ["public", "VIEW", ORG_AGGREGATION_VIEW, ORG_AGGREGATION_SQL_OLD]
+    );
+  }
+}

--- a/web/src/Components/Common/FilterBar/index.ts
+++ b/web/src/Components/Common/FilterBar/index.ts
@@ -18,3 +18,9 @@ export type {
   PaginatedSelectOptions,
   UsePaginatedSelectOptionsParams,
 } from "./usePaginatedSelectOptions";
+export { usePaginatedEntityFilter } from "./usePaginatedEntityFilter";
+export type {
+  FilterEntry,
+  PaginatedEntityFilter,
+  UsePaginatedEntityFilterParams,
+} from "./usePaginatedEntityFilter";

--- a/web/src/Components/Common/FilterBar/usePaginatedEntityFilter.ts
+++ b/web/src/Components/Common/FilterBar/usePaginatedEntityFilter.ts
@@ -1,0 +1,131 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useConnection } from "../../../Context/ConnectionContext/connectionContext";
+import { usePaginatedSelectOptions } from "./usePaginatedSelectOptions";
+import type {
+  FilterOption,
+  FilterValue,
+  MultiSelectFilterControl,
+  SingleSelectFilterControl,
+} from "./FilterBar";
+
+/** One AND-composed backend filter condition — mirrors the server's generic
+ * `{ key, operation, value }` filterAnd/filterOr entry shape. Any key/
+ * operation/value is valid (e.g. `{ key: "creditIssued", operation: ">",
+ * value: 0 }`); nothing here is specific to any one business rule. */
+export interface FilterEntry {
+  key: string;
+  operation: string;
+  value: unknown;
+}
+
+export interface UsePaginatedEntityFilterParams {
+  /** Any POST list endpoint following the standard QueryDto request /
+   * DataListResponseDto response shape - not specific to any one entity. */
+  endpoint: string;
+  /** FilterBar control id, e.g. "project" or "organization". */
+  id: string;
+  placeholder?: string;
+  mode: "multiple" | "single";
+  width?: number | string;
+  /** Response field read as the option label (ignored if `mapRow` given). */
+  labelKey?: string;
+  /** Response field read as the option value (ignored if `mapRow` given). */
+  valueKey?: string;
+  /** Escape hatch replacing the default `row[labelKey]`/`row[valueKey]`
+   * mapper - required if labelKey/valueKey aren't supplied. */
+  mapRow?: (row: any) => FilterOption;
+  /** Backend field the search box filters against (`like %term%`).
+   * Defaults to `labelKey`. */
+  searchKey?: string;
+  sortKey?: string;
+  sortOrder?: "ASC" | "DESC";
+  /** Extra AND-composed conditions always sent alongside the live search
+   * term - the caller's own scoping/business rule, e.g. `[{ key:
+   * "creditIssued", operation: ">", value: 0 }]`. Static for the
+   * component's lifetime: changing this value across renders does not
+   * itself trigger a re-fetch of already-loaded pages (the same way a
+   * changed `fetchPage` closure wouldn't have before this hook existed). */
+  extraFilters?: FilterEntry[];
+  selectedValues: FilterValue[];
+  pageSize?: number;
+  minFill?: number;
+}
+
+export interface PaginatedEntityFilter {
+  /** Ready to place directly in FilterBar's `controls` array. */
+  control: MultiSelectFilterControl | SingleSelectFilterControl;
+  options: FilterOption[];
+  loading: boolean;
+}
+
+/**
+ * Drives a server-searched, infinite-scroll-paginated FilterBar select
+ * against any list endpoint, and hands back a ready-to-use control object
+ * instead of just the raw paginated-options state - eliminating the
+ * fetchPage-closure + control-object boilerplate every such filter used to
+ * duplicate. All entity-specific behavior (which endpoint, which fields,
+ * which extra scoping conditions) is supplied by the caller; the actual
+ * pagination/search/scroll/sticky-cache mechanics live in
+ * usePaginatedSelectOptions, which this hook composes rather than
+ * reimplements.
+ */
+export const usePaginatedEntityFilter = ({
+  endpoint,
+  id,
+  placeholder,
+  mode,
+  width = 220,
+  labelKey,
+  valueKey,
+  mapRow,
+  searchKey,
+  sortKey,
+  sortOrder = "ASC",
+  extraFilters,
+  selectedValues,
+  pageSize,
+  minFill,
+}: UsePaginatedEntityFilterParams): PaginatedEntityFilter => {
+  const { post } = useConnection();
+  const effectiveSearchKey = searchKey ?? labelKey;
+
+  const select = usePaginatedSelectOptions({
+    selectedValues,
+    pageSize,
+    minFill,
+    fetchPage: async ({ search, page, size }) => {
+      const filterAnd: FilterEntry[] = [...(extraFilters ?? [])];
+      if (search && effectiveSearchKey) {
+        filterAnd.push({ key: effectiveSearchKey, operation: "like", value: `%${search}%` });
+      }
+      const response: any = await post(endpoint, {
+        page,
+        size,
+        filterAnd: filterAnd.length > 0 ? filterAnd : undefined,
+        sort: sortKey ? { key: sortKey, order: sortOrder } : undefined,
+      });
+      const rows: any[] = response?.data ?? [];
+      return rows.map(
+        (row): FilterOption =>
+          mapRow ? mapRow(row) : { label: row[labelKey as string], value: row[valueKey as string] }
+      );
+    },
+  });
+
+  const base = {
+    id,
+    type: "select" as const,
+    placeholder,
+    options: select.options,
+    width,
+    serverSearch: true,
+    loading: select.loading,
+    onSearch: select.onSearch,
+    onPopupScroll: select.onPopupScroll,
+    onDropdownVisibleChange: (open: boolean) => open && select.onDropdownOpen(),
+  };
+  const control: MultiSelectFilterControl | SingleSelectFilterControl =
+    mode === "multiple" ? { ...base, mode: "multiple" } : { ...base, mode: "single" };
+
+  return { control, options: select.options, loading: select.loading };
+};

--- a/web/src/Components/Company/CompanyProfile/organizationTransactionsTable.tsx
+++ b/web/src/Components/Company/CompanyProfile/organizationTransactionsTable.tsx
@@ -12,7 +12,7 @@ import {
   FilterBar,
   FilterValue,
   FilterValues,
-  usePaginatedSelectOptions,
+  usePaginatedEntityFilter,
 } from '../../Common/FilterBar';
 
 export enum OrganizationTransactionStatus {
@@ -109,19 +109,19 @@ export const OrganizationTransactionsTable = ({
   const [filterValues, setFilterValues] = useState<FilterValues>(INITIAL_FILTER_VALUES);
 
   // Project dropdown loads lazily, page-by-page, and searches server-side
-  // (see usePaginatedSelectOptions) rather than preloading the whole list.
-  const projectSelect = usePaginatedSelectOptions({
+  // (see usePaginatedEntityFilter) rather than preloading the whole list.
+  // The transactions view's projectId column is the project's refId; only
+  // projects with at least one issued credit are worth offering here.
+  const projectFilter = usePaginatedEntityFilter({
+    endpoint: API_PATHS.GET_PROJECT,
+    id: 'project',
+    mode: 'multiple',
+    placeholder: t('filterByProject'),
+    labelKey: 'title',
+    valueKey: 'refId',
+    sortKey: 'title',
+    extraFilters: [{ key: 'creditIssued', operation: '>', value: 0 }],
     selectedValues: filterValues.project as FilterValue[],
-    fetchPage: async ({ search, page, size }) => {
-      const response: any = await post(API_PATHS.GET_PROJECT, {
-        page,
-        size,
-        filterAnd: search ? [{ key: 'title', operation: 'like', value: `%${search}%` }] : undefined,
-        sort: { key: 'title', order: 'ASC' },
-      });
-      // The transactions view's projectId column is the project's refId.
-      return (response?.data ?? []).map((d: any) => ({ label: d.title, value: d.refId }));
-    },
   });
 
   const getQueryData = async () => {
@@ -231,7 +231,13 @@ export const OrganizationTransactionsTable = ({
       title: t('companyProfile:updatedDateTime'),
       key: 'updatedDate',
       sorter: true,
-      defaultSortOrder: 'descend' as const,
+      // No defaultSortOrder: antd would report this column as already
+      // actively sorted on the very first table interaction (including a
+      // plain page turn), which falsely looks like a user-driven sort
+      // change to the effect below and resets currentPage back to 1 —
+      // breaking the first pagination click. The default DESC ordering is
+      // already applied server-side (see getQueryData's `sort` fallback)
+      // without needing this visual hint.
       align: 'left' as const,
       render: (record: OrganizationTransactionInterface) => (
         <span>{moment(Number(record.updatedDate)).format('YYYY-MM-DD HH:mm:ss')}</span>
@@ -262,7 +268,6 @@ export const OrganizationTransactionsTable = ({
 
   useEffect(() => {
     getQueryData();
-    isInitialRender.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -283,6 +288,16 @@ export const OrganizationTransactionsTable = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortField, sortOrder, companyId, filterValues.status, filterValues.project]);
+
+  // Declared last so it runs after the two effects above on the initial
+  // mount pass (effects fire in declaration order within the same commit) —
+  // flipping this here, rather than inside the first effect, is what keeps
+  // their `isInitialRender.current` check false during that mount pass, so
+  // they don't also redundantly re-fetch alongside the unconditional mount
+  // fetch above.
+  useEffect(() => {
+    isInitialRender.current = true;
+  }, []);
 
   const allStatusesSelected = (filterValues.status as string[]).includes(STATUS_ALL);
 
@@ -313,21 +328,7 @@ export const OrganizationTransactionsTable = ({
           // as an applied-filter chip.
           isApplied: () => !allStatusesSelected,
         }}
-        controls={[
-          {
-            id: 'project',
-            type: 'select',
-            mode: 'multiple',
-            placeholder: t('filterByProject'),
-            options: projectSelect.options,
-            width: 220,
-            serverSearch: true,
-            loading: projectSelect.loading,
-            onSearch: projectSelect.onSearch,
-            onPopupScroll: projectSelect.onPopupScroll,
-            onDropdownVisibleChange: (open) => open && projectSelect.onDropdownOpen(),
-          },
-        ]}
+        controls={[projectFilter.control]}
         values={filterValues}
         onChange={(id, value) => setFilterValues((prev) => ({ ...prev, [id]: value }))}
         onClearAll={() => setFilterValues(INITIAL_FILTER_VALUES)}

--- a/web/src/Components/CreditHistoryGraph/BinaryTreeGraphView.tsx
+++ b/web/src/Components/CreditHistoryGraph/BinaryTreeGraphView.tsx
@@ -17,6 +17,8 @@ import {
   areNodesMeasured,
   effectiveChildren,
   fitGraphToScreen,
+  FIT_EXTRA_TOP,
+  FIT_EXTRA_RIGHT_TOOLBAR,
   mixHexColor,
   pathSegmentProgress,
   withFitMaxZoom,
@@ -26,8 +28,6 @@ const elk = new ELK();
 const NODE_HEIGHT = 100;
 // Matches the <ReactFlow maxZoom> below — restored after a fit's zoom cap.
 const DEFAULT_MAX_ZOOM = 3;
-// Fixed clearance reserved for the floating toolbar when fitting.
-const TOOLBAR_CLEARANCE = 60;
 // Per-level stagger of the path-highlight cascade.
 const PATH_STAGGER_MS = 90;
 const PATH_TRANSITION_MS = 260;
@@ -464,9 +464,9 @@ export const BinaryTreeGraphView = ({
         getNodes,
         withFitMaxZoom(fitBounds, (z) => storeApi.getState().setMaxZoom(z), maxZoom, DEFAULT_MAX_ZOOM),
         {
-          extraTop: 40,
+          extraTop: FIT_EXTRA_TOP,
           // Clearance so the top-right node isn't tucked under the toolbar.
-          extraRight: TOOLBAR_CLEARANCE,
+          extraRight: FIT_EXTRA_RIGHT_TOOLBAR,
           filter: useScope ? (n) => initialFitIds.has(n.id) : undefined,
         }
       );

--- a/web/src/Components/CreditHistoryGraph/CreditHistoryGraph.tsx
+++ b/web/src/Components/CreditHistoryGraph/CreditHistoryGraph.tsx
@@ -13,6 +13,8 @@ import {
   findDefaultTarget,
   findNodeByRange,
   fitGraphToScreen,
+  FIT_EXTRA_TOP,
+  FIT_EXTRA_RIGHT_TOOLBAR,
   getPathToRoot,
   measureNoteWidth,
   withFitMaxZoom,
@@ -224,7 +226,8 @@ const GraphToolbarAndView = ({
   const storeApi = useStoreApi();
   // getExtraRight: reserve room for Timeline's overflowing note text (Binary
   // Tree keeps info inside the node). extraRight: fixed gap for the floating
-  // toolbar, only needed in Binary Tree.
+  // toolbar, only needed in Binary Tree. extraTop: clearance for the
+  // floating mode-toggle/toolbar, needed regardless of mode.
   const fitToScreen = () =>
     fitGraphToScreen(
       getNodes,
@@ -239,7 +242,8 @@ const GraphToolbarAndView = ({
                   `${n.data?.creditMarker ? `${n.data.creditMarker}    ` : ""}${n.data?.notePrefix ?? ""}${n.data?.companyName ?? ""}${n.data?.updateTime ? ` | ${n.data.updateTime}` : ""}`
                 )
             : undefined,
-        extraRight: mode === "binary" ? 60 : 0,
+        extraTop: FIT_EXTRA_TOP,
+        extraRight: mode === "binary" ? FIT_EXTRA_RIGHT_TOOLBAR : 0,
       }
     );
 

--- a/web/src/Components/CreditHistoryGraph/TimelineGraphView.tsx
+++ b/web/src/Components/CreditHistoryGraph/TimelineGraphView.tsx
@@ -19,6 +19,7 @@ import {
   areNodesMeasured,
   effectiveChildren,
   fitGraphToScreen,
+  FIT_EXTRA_TOP,
   measureNoteWidth,
   mixHexColor,
   pathSegmentProgress,
@@ -553,9 +554,9 @@ export const TimelineGraphView = ({
             measureNoteWidth(
               `${n.data?.creditMarker ? `${n.data.creditMarker}    ` : ""}${n.data?.notePrefix ?? ""}${n.data?.companyName ?? ""}${n.data?.updateTime ? ` | ${n.data.updateTime}` : ""}`
             ),
-          // Headroom so the path-only fit doesn't tuck the top node under the
-          // floating mode-toggle.
-          extraTop: useScope ? 40 : 0,
+          // Headroom so the fit doesn't tuck the top node under the floating
+          // mode-toggle — needed regardless of fit scope.
+          extraTop: FIT_EXTRA_TOP,
           filter: useScope ? (n) => initialFitIds.has(n.id) : undefined,
         }
       );

--- a/web/src/Components/CreditHistoryGraph/creditHistoryGraph.utils.ts
+++ b/web/src/Components/CreditHistoryGraph/creditHistoryGraph.utils.ts
@@ -204,6 +204,12 @@ export const pathSegmentProgress = (segmentIndex: number, totalSegments: number,
   return easeOutCubic(segT);
 };
 
+// Fixed clearance reserved when fitting so content doesn't tuck under the
+// floating mode-toggle (top-left) / vertical toolbar (top-right). Shared by
+// every fitGraphToScreen call site so the two never drift out of sync again.
+export const FIT_EXTRA_TOP = 40;
+export const FIT_EXTRA_RIGHT_TOOLBAR = 60;
+
 interface FitGraphNode {
   id: string;
   position: { x: number; y: number };

--- a/web/src/Pages/CreditPages/Components/creditBalanceTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditBalanceTable.tsx
@@ -415,7 +415,6 @@ export const CreditBalanceTableComponent = (props: any) => {
 
   useEffect(() => {
     getQueryData();
-    isInitialRender.current = true;
   }, []);
 
   useEffect(() => {
@@ -433,6 +432,16 @@ export const CreditBalanceTableComponent = (props: any) => {
       }
     }
   }, [sortField, sortOrder, search, checkBoxOptions]);
+
+  // Declared last so it runs after the two effects above on the initial
+  // mount pass (effects fire in declaration order within the same commit) —
+  // flipping this here, rather than inside the first effect, is what keeps
+  // their `isInitialRender.current` check false during that mount pass, so
+  // they don't also redundantly re-fetch alongside the unconditional mount
+  // fetch above.
+  useEffect(() => {
+    isInitialRender.current = true;
+  }, []);
 
   const onFinishAction = async (
     reciveParty: any,

--- a/web/src/Pages/CreditPages/Components/creditBlockList.tsx
+++ b/web/src/Pages/CreditPages/Components/creditBlockList.tsx
@@ -32,7 +32,7 @@ import {
   FilterBar,
   FilterValue,
   FilterValues,
-  usePaginatedSelectOptions,
+  usePaginatedEntityFilter,
 } from "../../../Components/Common/FilterBar";
 import { getCreditBlockStatusTagColor } from "./creditTableHelpers";
 
@@ -208,32 +208,30 @@ export const CreditBlockListTableComponent = ({ t }: CreditBlockListTableProps) 
   const [historyEntries, setHistoryEntries] = useState<CreditHistoryEntry[]>([]);
 
   // Org & Project dropdowns load lazily, page-by-page, and search server-side
-  // (see usePaginatedSelectOptions) rather than preloading the whole list.
-  const orgSelect = usePaginatedSelectOptions({
+  // (see usePaginatedEntityFilter) rather than preloading the whole list.
+  const orgFilter = usePaginatedEntityFilter({
+    endpoint: API_PATHS.ORGANIZATION_NAMES,
+    id: "organization",
+    mode: "multiple",
+    placeholder: t("filterByOrganization"),
+    labelKey: "name",
+    valueKey: "companyId",
+    sortKey: "name",
     selectedValues: filterValues.organization as FilterValue[],
-    fetchPage: async ({ search, page, size }) => {
-      const response: any = await post(API_PATHS.ORGANIZATION_NAMES, {
-        page,
-        size,
-        filterAnd: search ? [{ key: "name", operation: "like", value: `%${search}%` }] : undefined,
-        sort: { key: "name", order: "ASC" },
-      });
-      return (response?.data ?? []).map((d: any) => ({ label: d.name, value: d.companyId }));
-    },
   });
 
-  const projectSelect = usePaginatedSelectOptions({
+  // The explorer view's projectId column is the project's refId; only
+  // projects with at least one issued credit are worth offering here.
+  const projectFilter = usePaginatedEntityFilter({
+    endpoint: API_PATHS.GET_PROJECT,
+    id: "project",
+    mode: "multiple",
+    placeholder: t("filterByProject"),
+    labelKey: "title",
+    valueKey: "refId",
+    sortKey: "title",
+    extraFilters: [{ key: "creditIssued", operation: ">", value: 0 }],
     selectedValues: filterValues.project as FilterValue[],
-    fetchPage: async ({ search, page, size }) => {
-      const response: any = await post(API_PATHS.GET_PROJECT, {
-        page,
-        size,
-        filterAnd: search ? [{ key: "title", operation: "like", value: `%${search}%` }] : undefined,
-        sort: { key: "title", order: "ASC" },
-      });
-      // The explorer view's projectId column is the project's refId.
-      return (response?.data ?? []).map((d: any) => ({ label: d.title, value: d.refId }));
-    },
   });
 
   const getQueryData = async () => {
@@ -496,7 +494,6 @@ export const CreditBlockListTableComponent = ({ t }: CreditBlockListTableProps) 
 
   useEffect(() => {
     getQueryData();
-    isInitialRender.current = true;
   }, []);
 
   useEffect(() => {
@@ -521,6 +518,16 @@ export const CreditBlockListTableComponent = ({ t }: CreditBlockListTableProps) 
     filterValues.project,
     appliedSerialSearch,
   ]);
+
+  // Declared last so it runs after the two effects above on the initial
+  // mount pass (effects fire in declaration order within the same commit) —
+  // flipping this here, rather than inside the first effect, is what keeps
+  // their `isInitialRender.current` check false during that mount pass, so
+  // they don't also redundantly re-fetch alongside the unconditional mount
+  // fetch above.
+  useEffect(() => {
+    isInitialRender.current = true;
+  }, []);
 
   const allStatusesSelected = (filterValues.status as string[]).includes(STATUS_ALL);
 
@@ -567,32 +574,8 @@ export const CreditBlockListTableComponent = ({ t }: CreditBlockListTableProps) 
               content: <SerialSearchInfoContent t={t} />,
             },
           },
-          {
-            id: "organization",
-            type: "select",
-            mode: "multiple",
-            placeholder: t("filterByOrganization"),
-            options: orgSelect.options,
-            width: 220,
-            serverSearch: true,
-            loading: orgSelect.loading,
-            onSearch: orgSelect.onSearch,
-            onPopupScroll: orgSelect.onPopupScroll,
-            onDropdownVisibleChange: (open) => open && orgSelect.onDropdownOpen(),
-          },
-          {
-            id: "project",
-            type: "select",
-            mode: "multiple",
-            placeholder: t("filterByProject"),
-            options: projectSelect.options,
-            width: 220,
-            serverSearch: true,
-            loading: projectSelect.loading,
-            onSearch: projectSelect.onSearch,
-            onPopupScroll: projectSelect.onPopupScroll,
-            onDropdownVisibleChange: (open) => open && projectSelect.onDropdownOpen(),
-          },
+          orgFilter.control,
+          projectFilter.control,
         ]}
         values={filterValues}
         appliedValues={{ serialSearch: appliedSerialSearch }}

--- a/web/src/Pages/CreditPages/Components/creditIssuanceTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditIssuanceTable.tsx
@@ -29,8 +29,9 @@ import { CreditHistoryGraph } from "../../../Components/CreditHistoryGraph/Credi
 import { ProjectDetailsLink } from "./ProjectDetailsLink";
 import {
   FilterBar,
+  FilterValue,
   FilterValues,
-  usePaginatedSelectOptions,
+  usePaginatedEntityFilter,
 } from "../../../Components/Common/FilterBar";
 
 enum CreditIssuanceColumns {
@@ -108,32 +109,30 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
   const [filterValues, setFilterValues] = useState<FilterValues>(INITIAL_FILTER_VALUES);
 
   // Org & Project dropdowns load lazily, page-by-page, and search server-side
-  // (see usePaginatedSelectOptions) rather than preloading the whole list.
-  const orgSelect = usePaginatedSelectOptions({
-    selectedValues: filterValues.organization as (string | number)[],
-    fetchPage: async ({ search, page, size }) => {
-      const response: any = await post(API_PATHS.ORGANIZATION_NAMES, {
-        page,
-        size,
-        filterAnd: search ? [{ key: "name", operation: "like", value: `%${search}%` }] : undefined,
-        sort: { key: "name", order: "ASC" },
-      });
-      return (response?.data ?? []).map((d: any) => ({ label: d.name, value: d.companyId }));
-    },
+  // (see usePaginatedEntityFilter) rather than preloading the whole list.
+  const orgFilter = usePaginatedEntityFilter({
+    endpoint: API_PATHS.ORGANIZATION_NAMES,
+    id: "organization",
+    mode: "multiple",
+    placeholder: t("filterByOrganization"),
+    labelKey: "name",
+    valueKey: "companyId",
+    sortKey: "name",
+    selectedValues: filterValues.organization as FilterValue[],
   });
 
-  const projectSelect = usePaginatedSelectOptions({
-    selectedValues: filterValues.project as (string | number)[],
-    fetchPage: async ({ search, page, size }) => {
-      const response: any = await post(API_PATHS.GET_PROJECT, {
-        page,
-        size,
-        filterAnd: search ? [{ key: "title", operation: "like", value: `%${search}%` }] : undefined,
-        sort: { key: "title", order: "ASC" },
-      });
-      // The issuances view's projectId column is the project's refId.
-      return (response?.data ?? []).map((d: any) => ({ label: d.title, value: d.refId }));
-    },
+  // The issuances view's projectId column is the project's refId; only
+  // projects with at least one issued credit are worth offering here.
+  const projectFilter = usePaginatedEntityFilter({
+    endpoint: API_PATHS.GET_PROJECT,
+    id: "project",
+    mode: "multiple",
+    placeholder: t("filterByProject"),
+    labelKey: "title",
+    valueKey: "refId",
+    sortKey: "title",
+    extraFilters: [{ key: "creditIssued", operation: ">", value: 0 }],
+    selectedValues: filterValues.project as FilterValue[],
   });
 
   const getQueryData = async () => {
@@ -333,7 +332,6 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
 
   useEffect(() => {
     getQueryData();
-    isInitialRender.current = true;
   }, []);
 
   useEffect(() => {
@@ -352,37 +350,22 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
     }
   }, [sortField, sortOrder, filterValues.organization, filterValues.project, filterValues.vintage]);
 
+  // Declared last so it runs after the two effects above on the initial
+  // mount pass (effects fire in declaration order within the same commit) —
+  // flipping this here, rather than inside the first effect, is what keeps
+  // their `isInitialRender.current` check false during that mount pass, so
+  // they don't also redundantly re-fetch alongside the unconditional mount
+  // fetch above.
+  useEffect(() => {
+    isInitialRender.current = true;
+  }, []);
+
   return (
     <div className="content-card">
       <FilterBar
         controls={[
-          {
-            id: "organization",
-            type: "select",
-            mode: "multiple",
-            visible: !isProjectDeveloper,
-            placeholder: t("filterByOrganization"),
-            options: orgSelect.options,
-            width: 220,
-            serverSearch: true,
-            loading: orgSelect.loading,
-            onSearch: orgSelect.onSearch,
-            onPopupScroll: orgSelect.onPopupScroll,
-            onDropdownVisibleChange: (open) => open && orgSelect.onDropdownOpen(),
-          },
-          {
-            id: "project",
-            type: "select",
-            mode: "multiple",
-            placeholder: t("filterByProject"),
-            options: projectSelect.options,
-            width: 220,
-            serverSearch: true,
-            loading: projectSelect.loading,
-            onSearch: projectSelect.onSearch,
-            onPopupScroll: projectSelect.onPopupScroll,
-            onDropdownVisibleChange: (open) => open && projectSelect.onDropdownOpen(),
-          },
+          { ...orgFilter.control, visible: !isProjectDeveloper },
+          projectFilter.control,
           {
             id: "vintage",
             type: "year",

--- a/web/src/Pages/CreditPages/Components/creditRetirementsTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditRetirementsTable.tsx
@@ -440,7 +440,6 @@ export const CreditRetirementsTableComponent = (props: any) => {
 
   useEffect(() => {
     getQueryData();
-    isInitialRender.current = true;
   }, []);
 
   useEffect(() => {
@@ -458,6 +457,16 @@ export const CreditRetirementsTableComponent = (props: any) => {
       }
     }
   }, [sortField, sortOrder, search, checkBoxOptions]);
+
+  // Declared last so it runs after the two effects above on the initial
+  // mount pass (effects fire in declaration order within the same commit) —
+  // flipping this here, rather than inside the first effect, is what keeps
+  // their `isInitialRender.current` check false during that mount pass, so
+  // they don't also redundantly re-fetch alongside the unconditional mount
+  // fetch above.
+  useEffect(() => {
+    isInitialRender.current = true;
+  }, []);
   const onFinishAction = async (
     transactionId: any,
     action: RetirementActionEnum,

--- a/web/src/Pages/CreditPages/Components/creditTransfersTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditTransfersTable.tsx
@@ -273,7 +273,6 @@ export const CreditTransfersTableComponent = (props: any) => {
 
   useEffect(() => {
     getQueryData();
-    isInitialRender.current = true;
   }, []);
 
   useEffect(() => {
@@ -291,6 +290,16 @@ export const CreditTransfersTableComponent = (props: any) => {
       }
     }
   }, [sortField, sortOrder, search]);
+
+  // Declared last so it runs after the two effects above on the initial
+  // mount pass (effects fire in declaration order within the same commit) —
+  // flipping this here, rather than inside the first effect, is what keeps
+  // their `isInitialRender.current` check false during that mount pass, so
+  // they don't also redundantly re-fetch alongside the unconditional mount
+  // fetch above.
+  useEffect(() => {
+    isInitialRender.current = true;
+  }, []);
   // MARK: Main JSX START
 
   return (


### PR DESCRIPTION
Four related fixes/improvements bundled together: tightens which retirements count as "retired" for org credit totals, extracts a reusable paginated entity-filter dropdown and restricts the Project filter to projects with issued credits, fixes floating UI overlapping the credit history graph on fit-to-screen, and fixes six credit tables firing duplicate requests on initial load.

**Backend — retirement status filte**r (credit.block.org.aggregation.view. entity.ts, credit.block.org.transactions.view.entity.ts, new migration 1785400000000-RequireCompletedForOrgCreditRetired.ts):
- Both org-credit views' "Retired" branch now requires ct.status = 'Completed' (previously ct.status != 'Pending', which still counted a Rejected/Cancelled retirement as retired). Forward-fix migration only — the two already-applied migrations (ExcludePendingFromOrgCreditRetired, AddOrgCreditReceived) are left untouched per this repo's convention of never editing an applied migration.

**Frontend — reusable paginated entity-filter + creditIssued>0 project filter** (usePaginatedEntityFilter.ts new, FilterBar/index.ts, organizationTransactionsTable.tsx, creditBlockList.tsx, creditIssuanceTable.tsx):
- New usePaginatedEntityFilter hook (Components/Common/FilterBar): wraps the existing usePaginatedSelectOptions engine and returns a ready-to-place FilterBar control object instead of just raw paginated-options state, eliminating the near-identical fetchPage + control-object boilerplate that was triplicated across the Explorer, Issuance, and Organisation Details transaction tables. endpoint and extraFilters are fully generic, caller-supplied props — nothing entity-specific is hardcoded in the hook.
- Migrated both the Project and Organization filter dropdowns in all three tables to the new hook.
- New business rule: the Project filter now only offers projects with creditIssued > 0 (extraFilters: [{key:"creditIssued", operation:">", value:0}]), via the already-existing creditIssued column on project_view_entity — no backend change needed for this part.

**Frontend — Credit History Graph floating overlay overlap** (creditHistoryGraph.utils.ts, CreditHistoryGraph.tsx, BinaryTreeGraphView.tsx, TimelineGraphView.tsx):
- Added shared FIT_EXTRA_TOP / FIT_EXTRA_RIGHT_TOOLBAR constants (creditHistoryGraph.utils.ts) — previously each of the three fitGraphToScreen call sites hardcoded its own top/right clearance literal for the floating mode-toggle/toolbar, and one site (the toolbar's own "Fit to screen" button in CreditHistoryGraph.tsx) was missing top clearance entirely, letting the top node get tucked under the floating toggle/toolbar.
- Fixed: toolbar's fitToScreen now passes extraTop; Binary Tree's fit effect uses the shared constants instead of a local one; Timeline's fit effect now reserves top clearance unconditionally instead of only when fit-scoped to a path.

**Frontend — duplicate requests on initial load** (organizationTransactions Table.tsx, creditBlockList.tsx, creditIssuanceTable.tsx, creditTransfersTable.tsx, creditRetirementsTable.tsx, creditBalanceTable.tsx):
- Root cause: each table set an isInitialRender ref to true synchronously inside its first (unconditional mount-fetch) effect. Every useEffect scheduled by a component's initial render fires in declaration order within the same commit regardless of dependency array, so the page/pageSize effect and the sort/filter effect declared after it also saw the flag already true on that same mount and redundantly re-fetched — 2-3 duplicate requests on every initial page load (reported first via national/creditTransactionsManagement/ orgCreditBlocks; confirmed identical in five sibling tables).
- Fix: moved the flag flip out of the first effect into its own effect declared last, after the page and sort/filter effects — declaration order guarantees it now runs after those two have had their (now correctly skipped) first pass on mount.

**Potential impact areas:**
- Org credit retired totals (View Organisations table, org profile summary card, orgCreditBlocks feed) will now show slightly lower "retired" figures wherever a retirement was ever Rejected/Cancelled after being requested — previously miscounted as retired.
- The Project filter dropdown in Explorer/Issuance/Organisation Details will no longer list projects that have never had a credit issued — intentional, but flag if any workflow relied on selecting such a project from that specific dropdown.
- The six duplicate-request fixes change only fetch timing/count, not request payloads or displayed data — no behavioral change expected beyond fewer network calls.