### PR TITLE
project filter fix

### DIFF
--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
@@ -23,6 +23,7 @@ import { QueryDto } from "../dto/query.dto";
 import { DataListResponseDto } from "../dto/data.list.response";
 import { CreditBlockBalancesViewEntity } from "../view-entities/credit.block.balances.view.entity";
 import { FilterEntry } from "../dto/filter.entry";
+import { ProjectEntity } from "../entities/projects.entity";
 import { CreditBlockTransfersViewEntity } from "../view-entities/credit.block.transfers.view.entity";
 import { CreditBlockRetirementsViewEntity } from "../view-entities/credit.block.retirements.view.entity";
 import { CreditBlockExplorerViewEntity } from "../view-entities/credit.block.explorer.view.entity";
@@ -801,6 +802,54 @@ export class CreditTransactionsManagementService {
       resp.length > 0 ? resp[0] : undefined,
       resp.length > 1 ? resp[1] : undefined
     );
+  }
+
+  public async queryBalanceProjectNames(
+    query: QueryDto,
+    abilityCondition: string,
+    user: User
+  ): Promise<DataListResponseDto> {
+    query.page = query.page || 1;
+    query.size = query.size || 10;
+    if (user.companyRole == CompanyRole.INDEPENDENT_CERTIFIER) {
+      throw new HttpException(
+        this.helperService.formatReqMessagesString(
+          "creditTransaction.unauthorized",
+          []
+        ),
+        HttpStatus.BAD_REQUEST
+      );
+    }
+
+    const scopeFilters: FilterEntry[] = [
+      { key: "ownerCompanyId", operation: "!=", value: 0 },
+    ];
+    if (user.companyRole == CompanyRole.PROJECT_DEVELOPER) {
+      scopeFilters.push({
+        key: "ownerCompanyId",
+        operation: "=",
+        value: user.companyId,
+      });
+    }
+    query.filterAnd
+      ? query.filterAnd.push(...scopeFilters)
+      : (query.filterAnd = scopeFilters);
+
+    const resp = await this.creditBlocksEntityRepository
+      .createQueryBuilder("cb")
+      .innerJoin(ProjectEntity, "p", 'cb."projectRefId" = p."refId"')
+      .select('p."title"', "projectName")
+      .addSelect(
+        `string_agg(DISTINCT cb."projectRefId", ',' ORDER BY cb."projectRefId")`,
+        "projectIds"
+      )
+      .groupBy('p."title"')
+      .where(this.helperService.generateWhereSQL(query, abilityCondition))
+      .orderBy(query?.sort?.key && `"${query?.sort?.key}"`, query?.sort?.order)
+      .offset(query.size * query.page - query.size)
+      .limit(query.size)
+      .getRawMany();
+    return new DataListResponseDto(resp, undefined);
   }
 
   public async queryTransfers(

--- a/backend/services/src/national-api/credit.transactions.management.controller.ts
+++ b/backend/services/src/national-api/credit.transactions.management.controller.ts
@@ -118,6 +118,23 @@ export class CreditTransactionsManagementController {
   @CheckPolicies((ability: AppAbility) =>
     ability.can(Action.Read, ProjectEntity)
   )
+  @Post("queryBalanceProjectNames")
+  async queryBalanceProjectNames(
+    @Body() queryDto: QueryDto,
+    @Request() req
+  ): Promise<any> {
+    return this.creditTransactionsManagementService.queryBalanceProjectNames(
+      queryDto,
+      req.abilityCondition,
+      req.user
+    );
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, PoliciesGuard)
+  @CheckPolicies((ability: AppAbility) =>
+    ability.can(Action.Read, ProjectEntity)
+  )
   @Post("queryTransfers")
   async queryTransfers(
     @Body() queryDto: QueryDto,

--- a/web/src/Components/Common/FilterBar/usePaginatedSelectOptions.ts
+++ b/web/src/Components/Common/FilterBar/usePaginatedSelectOptions.ts
@@ -76,8 +76,8 @@ export const usePaginatedSelectOptions = ({
   const hasMoreRef = useRef(true);
   const loadingRef = useRef(false);
   const initializedRef = useRef(false);
-  const debounceRef = useRef<NodeJS.Timeout | null>(null);
-  const loadedCountRef = useRef(0); // loaded so far this search — drives minFill
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const loadedValuesRef = useRef<Set<FilterValue>>(new Set());
   // Every option ever loaded, so selected values keep their labels.
   const cacheRef = useRef<Map<FilterValue, FilterOption>>(new Map());
   // Bumps per search/reset; a fetch resolving with a stale token is dropped.
@@ -91,19 +91,22 @@ export const usePaginatedSelectOptions = ({
       try {
         let page = startPage;
         let appendPage = append;
-        // Fetch pages until >= minFill options (scrollable) or the backend
-        // runs out; loops once when a single page already meets minFill.
+        // Fetch pages until >= minFill distinct options (scrollable) or the
+        // backend runs out; loops once when a single page already meets minFill.
         for (;;) {
           const search = searchRef.current;
           const isAppend = appendPage;
           const fetched = await fetchPage({ search, page, size: pageSize });
           if (token !== requestTokenRef.current) return; // superseded
-          fetched.forEach((option) => cacheRef.current.set(option.value, option));
+          if (!isAppend) loadedValuesRef.current.clear();
+          fetched.forEach((option) => {
+            cacheRef.current.set(option.value, option);
+            loadedValuesRef.current.add(option.value);
+          });
           pageRef.current = page;
           hasMoreRef.current = fetched.length === pageSize;
-          loadedCountRef.current = isAppend ? loadedCountRef.current + fetched.length : fetched.length;
           setPageOptions((prev) => (isAppend ? [...prev, ...fetched] : fetched));
-          if (!hasMoreRef.current || loadedCountRef.current >= minFill) break;
+          if (!hasMoreRef.current || loadedValuesRef.current.size >= minFill) break;
           page += 1;
           appendPage = true;
         }
@@ -127,7 +130,7 @@ export const usePaginatedSelectOptions = ({
       searchRef.current = search;
       pageRef.current = 0;
       hasMoreRef.current = true;
-      loadedCountRef.current = 0;
+      loadedValuesRef.current.clear();
       loadPage(1, false);
     },
     [loadPage]

--- a/web/src/Config/apiConfig.ts
+++ b/web/src/Config/apiConfig.ts
@@ -34,6 +34,8 @@ export const API_PATHS = {
   CREDIT_BALANCE_QUERY: "national/creditTransactionsManagement/queryBalance",
   CREDIT_BALANCE_BY_PROJECT_QUERY:
     "national/creditTransactionsManagement/queryBalanceByProject",
+  CREDIT_BALANCE_PROJECT_NAMES:
+    "national/creditTransactionsManagement/queryBalanceProjectNames",
   CREDIT_BALANCE_BY_ORGANIZATION_QUERY:
     "national/creditTransactionsManagement/queryBalanceByOrganization",
   CREDIT_TRANSFERS_QUERY:

--- a/web/src/Pages/CreditPages/Components/creditBalanceByProjectTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditBalanceByProjectTable.tsx
@@ -399,10 +399,12 @@ export const CreditBalanceByProjectTable = ({
       });
     }
     if (projects.length > 0) {
+      // Each selected value is one name's comma-joined project ids, so a single
+      // selection can expand to several projects.
       filterAnd.push({
         key: 'projectId',
         operation: 'in',
-        value: projects,
+        value: projects.flatMap((value) => value.split(',')),
       });
     }
 

--- a/web/src/Pages/CreditPages/Components/creditBalanceByProjectTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditBalanceByProjectTable.tsx
@@ -400,7 +400,7 @@ export const CreditBalanceByProjectTable = ({
     }
     if (projects.length > 0) {
       filterAnd.push({
-        key: 'projectName',
+        key: 'projectId',
         operation: 'in',
         value: projects,
       });

--- a/web/src/Pages/CreditPages/creditBalancePage.tsx
+++ b/web/src/Pages/CreditPages/creditBalancePage.tsx
@@ -81,23 +81,15 @@ export const CreditBalancePage = () => {
     selectedValues: (filterValues.organizations as FilterValue[]) ?? [],
   });
 
-  // Sourced from the same endpoint as the table, not projectManagement/query:
-  // that one is scoped by project ownership (companyId) while the table is
-  // scoped by credit holding (holderId), so a PD holding credits in a project
-  // it doesn't own saw the row but couldn't select it. This also offers only
-  // projects that actually have credit blocks, so no selection lands empty.
-  // Keyed on projectId rather than the title, which isn't unique.
   const projectFilter = usePaginatedEntityFilter({
-    endpoint: API_PATHS.CREDIT_BALANCE_BY_PROJECT_QUERY,
+    endpoint: API_PATHS.CREDIT_BALANCE_PROJECT_NAMES,
     id: 'projects',
     mode: 'multiple',
     placeholder: t('selectProject'),
     labelKey: 'projectName',
-    valueKey: 'projectId',
+    valueKey: 'projectIds',
+    searchKey: 'title',
     sortKey: 'projectName',
-    // No creditIssued filter: it isn't a column on the balance views, and the
-    // restriction is already structural — both views are built FROM
-    // credit_blocks_entity, so a project only appears once credits exist for it.
     selectedValues: (filterValues.projects as FilterValue[]) ?? [],
   });
 

--- a/web/src/Pages/CreditPages/creditBalancePage.tsx
+++ b/web/src/Pages/CreditPages/creditBalancePage.tsx
@@ -81,14 +81,23 @@ export const CreditBalancePage = () => {
     selectedValues: (filterValues.organizations as FilterValue[]) ?? [],
   });
 
+  // Sourced from the same endpoint as the table, not projectManagement/query:
+  // that one is scoped by project ownership (companyId) while the table is
+  // scoped by credit holding (holderId), so a PD holding credits in a project
+  // it doesn't own saw the row but couldn't select it. This also offers only
+  // projects that actually have credit blocks, so no selection lands empty.
+  // Keyed on projectId rather than the title, which isn't unique.
   const projectFilter = usePaginatedEntityFilter({
-    endpoint: API_PATHS.GET_PROJECT,
+    endpoint: API_PATHS.CREDIT_BALANCE_BY_PROJECT_QUERY,
     id: 'projects',
     mode: 'multiple',
     placeholder: t('selectProject'),
-    labelKey: 'title',
-    valueKey: 'title',
-    sortKey: 'title',
+    labelKey: 'projectName',
+    valueKey: 'projectId',
+    sortKey: 'projectName',
+    // No creditIssued filter: it isn't a column on the balance views, and the
+    // restriction is already structural — both views are built FROM
+    // credit_blocks_entity, so a project only appears once credits exist for it.
     selectedValues: (filterValues.projects as FilterValue[]) ?? [],
   });
 


### PR DESCRIPTION
Fixes the Credit Balance project filter showing only a few options instead of the full list, and moves it onto a dedicated project-names endpoint.
