### PR TITLE
fix(backend): sort Serial No numerically on Explorer, Issuance, and Org Credit Balance pages

### DIFF
--- a/backend/services/libs/shared/src/company/company.service.spec.ts
+++ b/backend/services/libs/shared/src/company/company.service.spec.ts
@@ -1,18 +1,81 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { CompanyService } from './company.service';
+import { CompanyService } from "./company.service";
+import { CompanyRole } from "../enum/company.role.enum";
 
-describe('CompanyService', () => {
+describe("CompanyService", () => {
   let service: CompanyService;
+  let orderByArgs: any[];
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [CompanyService],
-    }).compile();
+  beforeEach(() => {
+    orderByArgs = [];
+    const companyRepo: any = {
+      createQueryBuilder: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockImplementation((...args: any[]) => {
+          orderByArgs = args;
+          return {
+            offset: jest.fn().mockReturnThis(),
+            limit: jest.fn().mockReturnThis(),
+            getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+          };
+        }),
+      }),
+    };
+    const helperService: any = {
+      generateWhereSQL: jest.fn(),
+      parseMongoQueryToSQL: jest.fn(),
+    };
 
-    service = module.get<CompanyService>(CompanyService);
+    service = new CompanyService(
+      companyRepo,
+      {} as any, // userRepo
+      {} as any, // companyViewRepo
+      {} as any, // logger
+      {} as any, // configService
+      helperService,
+      {} as any, // programmeLedgerService
+      {} as any, // emailHelperService
+      {} as any, // programmeTransferRepo
+      {} as any, // fileHandler
+      {} as any, // counterService
+      {} as any, // userService
+      {} as any, // asyncOperationsInterface
+      {} as any, // locationService
+      {} as any, // investmentRepo
+      {} as any, // dataExportService
+      {} as any, // httpUtilService
+      {} as any, // cacheManager
+      {} as any, // creditBlocksEntityRepository
+      {} as any // creditBlockOrgAggregationViewEntityRepository
+    );
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(service).toBeDefined();
+  });
+
+  describe("query sorting", () => {
+    const companyRole = CompanyRole.DESIGNATED_NATIONAL_AUTHORITY;
+
+    it("sorts state alphabetically by displayed label instead of by enum ordinal", async () => {
+      await service.query(
+        { size: 10, page: 1, sort: { key: "state", order: "ASC" } } as any,
+        undefined,
+        companyRole
+      );
+
+      expect(orderByArgs[0]).toBe(
+        `CASE "state" WHEN '1' THEN 0 WHEN '0' THEN 1 WHEN '2' THEN 2 WHEN '3' THEN 3 ELSE 4 END`
+      );
+    });
+
+    it("keeps unrelated sort keys on the plain-column path (no regression)", async () => {
+      await service.query(
+        { size: 10, page: 1, sort: { key: "name", order: "DESC" } } as any,
+        undefined,
+        companyRole
+      );
+
+      expect(orderByArgs[0]).toBe(`"name"`);
+    });
   });
 });

--- a/backend/services/libs/shared/src/company/company.service.ts
+++ b/backend/services/libs/shared/src/company/company.service.ts
@@ -16,7 +16,10 @@ import { CompanyRole } from "../enum/company.role.enum";
 import { QueryDto } from "../dto/query.dto";
 import { DataListResponseDto } from "../dto/data.list.response";
 import { BasicResponseDto } from "../dto/basic.response.dto";
-import { CompanyState } from "../enum/company.state.enum";
+import {
+  CompanyState,
+  COMPANY_STATE_ALPHABETICAL_ORDER,
+} from "../enum/company.state.enum";
 import { HelperService } from "../util/helpers.service";
 import { FindOrganisationQueryDto } from "../dto/find.organisation.dto";
 import { ProgrammeLedgerService } from "../programme-ledger/programme-ledger.service";
@@ -624,7 +627,9 @@ export class CompanyService {
         )
       )
       .orderBy(
-        query?.sort?.key && `"${query?.sort?.key}"`,
+        query?.sort?.key === "state"
+          ? this.stateAlphabeticalExpr()
+          : query?.sort?.key && `"${query?.sort?.key}"`,
         query?.sort?.order,
         query?.sort?.nullFirst !== undefined
           ? query?.sort?.nullFirst === true
@@ -1435,5 +1440,21 @@ export class CompanyService {
     });
 
     return companies && companies.length > 0 ? companies[0] : undefined;
+  }
+
+  /**
+   * "state" is a native Postgres enum (company_state_enum), so a plain
+   * ORDER BY sorts by its declared ordinal (0,1,2,3), not by the displayed
+   * label ("Active"/"Deactivated"/"Pending"/"Rejected"). Sort by each
+   * state's position in COMPANY_STATE_ALPHABETICAL_ORDER instead. An
+   * unmapped value (e.g. a new CompanyState added without updating that
+   * list) falls into the ELSE bucket and sorts last, rather than breaking
+   * the query.
+   */
+  private stateAlphabeticalExpr(): string {
+    const whenClauses = COMPANY_STATE_ALPHABETICAL_ORDER.map(
+      (state, idx) => `WHEN '${state}' THEN ${idx}`
+    ).join(" ");
+    return `CASE "state" ${whenClauses} ELSE ${COMPANY_STATE_ALPHABETICAL_ORDER.length} END`;
   }
 }

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.spec.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.spec.ts
@@ -22,6 +22,9 @@ describe("CreditTransactionsManagementService", () => {
       take: jest.fn().mockReturnThis(),
       getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
     };
+    const creditBlockTransfersViewEntityRepository: any = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    };
     const creditBlockExplorerViewEntityRepository: any = {
       createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
     };
@@ -44,7 +47,7 @@ describe("CreditTransactionsManagementService", () => {
       {} as any, // creditTransactionsEntityRepository
       {} as any, // documentManagementService
       {} as any, // creditBlockBalancesViewEntityRepository
-      {} as any, // creditBlockTransfersViewEntityRepository
+      creditBlockTransfersViewEntityRepository,
       {} as any, // creditBlockRetirementsViewEntityRepository
       creditBlockExplorerViewEntityRepository,
       creditBlockIssuancesViewEntityRepository,
@@ -60,6 +63,36 @@ describe("CreditTransactionsManagementService", () => {
 
   it("should be defined", () => {
     expect(service).toBeDefined();
+  });
+
+  describe("queryTransfers sorting", () => {
+    const user: any = { companyRole: CompanyRole.DESIGNATED_NATIONAL_AUTHORITY };
+
+    it("sorts id numerically instead of lexicographically", async () => {
+      await service.queryTransfers(
+        { size: 10, page: 1, sort: { key: "id", order: "ASC" } } as any,
+        undefined,
+        user
+      );
+
+      expect(orderByCalls).toHaveLength(1);
+      expect(orderByCalls[0][0]).toBe(
+        `CASE WHEN "creditTx"."id" ~ '^[0-9]+$' THEN "creditTx"."id"::bigint END`
+      );
+      expect(orderByCalls[0][1]).toBe("ASC");
+    });
+
+    it("keeps unrelated sort keys on the plain-column path (no regression)", async () => {
+      await service.queryTransfers(
+        { size: 10, page: 1, sort: { key: "createdDate", order: "DESC" } } as any,
+        undefined,
+        user
+      );
+
+      expect(orderByCalls).toHaveLength(1);
+      expect(orderByCalls[0][0]).toBe(`"createdDate"`);
+      expect(orderByCalls[0][1]).toBe("DESC");
+    });
   });
 
   describe("queryExplorer sorting", () => {

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.spec.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.spec.ts
@@ -1,18 +1,176 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { CreditTransactionsManagementService } from './credit-transactions-management.service';
+import { CreditTransactionsManagementService } from "./credit-transactions-management.service";
+import { CompanyRole } from "../enum/company.role.enum";
 
-describe('CreditTransactionsManagementService', () => {
+describe("CreditTransactionsManagementService", () => {
   let service: CreditTransactionsManagementService;
+  let orderByCalls: any[][];
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [CreditTransactionsManagementService],
-    }).compile();
+  beforeEach(() => {
+    orderByCalls = [];
+    const queryBuilder: any = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockImplementation((...args: any[]) => {
+        orderByCalls = [args];
+        return queryBuilder;
+      }),
+      addOrderBy: jest.fn().mockImplementation((...args: any[]) => {
+        orderByCalls.push(args);
+        return queryBuilder;
+      }),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+    const creditBlockExplorerViewEntityRepository: any = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    };
+    const creditBlockIssuancesViewEntityRepository: any = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    };
+    const creditBlockOrgTransactionsViewEntityRepository: any = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    };
+    const helperService: any = {
+      generateWhereSQL: jest.fn().mockReturnValue(undefined),
+    };
 
-    service = module.get<CreditTransactionsManagementService>(CreditTransactionsManagementService);
+    service = new CreditTransactionsManagementService(
+      helperService,
+      {} as any, // companyService
+      {} as any, // programmeLedgerService
+      {} as any, // creditBlocksEntityRepository
+      {} as any, // counterService
+      {} as any, // creditTransactionsEntityRepository
+      {} as any, // documentManagementService
+      {} as any, // creditBlockBalancesViewEntityRepository
+      {} as any, // creditBlockTransfersViewEntityRepository
+      {} as any, // creditBlockRetirementsViewEntityRepository
+      creditBlockExplorerViewEntityRepository,
+      creditBlockIssuancesViewEntityRepository,
+      {} as any, // creditBlockOrgBalancesViewEntityRepository
+      {} as any, // creditBlockProjectBalancesViewEntityRepository
+      {} as any, // creditBlockProjectHolderBalancesViewEntityRepository
+      creditBlockOrgTransactionsViewEntityRepository,
+      {} as any, // aefReportManagementService
+      {} as any, // cooperativeApproachRepo
+      {} as any // serialNumberManagementService
+    );
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(service).toBeDefined();
+  });
+
+  describe("queryExplorer sorting", () => {
+    const user: any = { companyRole: CompanyRole.DESIGNATED_NATIONAL_AUTHORITY };
+
+    it("sorts serialNumber by its numeric segments instead of lexicographically", async () => {
+      await service.queryExplorer(
+        { size: 10, page: 1, sort: { key: "serialNumber", order: "ASC" } } as any,
+        undefined,
+        user
+      );
+
+      expect(orderByCalls).toHaveLength(2);
+      const [projectId, blockStart] = orderByCalls.map((call) => call[0]);
+      expect(projectId).toContain("split_part(\"creditBlock\".\"serialNumber\", '-', 4)::int");
+      expect(blockStart).toContain("split_part(\"creditBlock\".\"serialNumber\", '-', 5)::int");
+      orderByCalls.forEach((call) => expect(call[1]).toBe("ASC"));
+    });
+
+    it("keeps unrelated sort keys on the plain-column path (no regression)", async () => {
+      await service.queryExplorer(
+        { size: 10, page: 1, sort: { key: "projectName", order: "DESC" } } as any,
+        undefined,
+        user
+      );
+
+      expect(orderByCalls).toHaveLength(1);
+      expect(orderByCalls[0][0]).toBe(`"projectName"`);
+      expect(orderByCalls[0][1]).toBe("DESC");
+    });
+  });
+
+  describe("queryIssuances sorting", () => {
+    const user: any = { companyRole: CompanyRole.DESIGNATED_NATIONAL_AUTHORITY };
+
+    it("sorts serialNumber by its numeric segments instead of lexicographically", async () => {
+      await service.queryIssuances(
+        { size: 10, page: 1, sort: { key: "serialNumber", order: "ASC" } } as any,
+        undefined,
+        user
+      );
+
+      expect(orderByCalls).toHaveLength(2);
+      const [projectId, blockStart] = orderByCalls.map((call) => call[0]);
+      expect(projectId).toContain("split_part(\"creditTx\".\"serialNumber\", '-', 4)::int");
+      expect(blockStart).toContain("split_part(\"creditTx\".\"serialNumber\", '-', 5)::int");
+      orderByCalls.forEach((call) => expect(call[1]).toBe("ASC"));
+    });
+
+    it("keeps unrelated sort keys on the plain-column path (no regression)", async () => {
+      await service.queryIssuances(
+        { size: 10, page: 1, sort: { key: "issuanceDate", order: "DESC" } } as any,
+        undefined,
+        user
+      );
+
+      expect(orderByCalls).toHaveLength(1);
+      expect(orderByCalls[0][0]).toBe(`"issuanceDate"`);
+      expect(orderByCalls[0][1]).toBe("DESC");
+    });
+  });
+
+  describe("queryOrgCreditBlocks sorting", () => {
+    const user: any = { companyRole: CompanyRole.DESIGNATED_NATIONAL_AUTHORITY };
+
+    it("sorts serialNumber by its numeric segments instead of lexicographically", async () => {
+      await service.queryOrgCreditBlocks(
+        {
+          size: 10,
+          page: 1,
+          organizationId: 1,
+          sort: { key: "serialNumber", order: "ASC" },
+        } as any,
+        undefined,
+        user
+      );
+
+      expect(orderByCalls).toHaveLength(2);
+      const [projectId, blockStart] = orderByCalls.map((call) => call[0]);
+      expect(projectId).toContain("split_part(\"orgTx\".\"serialNumber\", '-', 4)::int");
+      expect(blockStart).toContain("split_part(\"orgTx\".\"serialNumber\", '-', 5)::int");
+      orderByCalls.forEach((call) => expect(call[1]).toBe("ASC"));
+    });
+
+    it("keeps unrelated sort keys on the plain-column path (no regression)", async () => {
+      await service.queryOrgCreditBlocks(
+        {
+          size: 10,
+          page: 1,
+          organizationId: 1,
+          sort: { key: "updatedDate", order: "DESC" },
+        } as any,
+        undefined,
+        user
+      );
+
+      expect(orderByCalls).toHaveLength(1);
+      expect(orderByCalls[0][0]).toBe(`"updatedDate"`);
+      expect(orderByCalls[0][1]).toBe("DESC");
+    });
+
+    it("falls back to updatedDate DESC when no sort key is given", async () => {
+      await service.queryOrgCreditBlocks(
+        { size: 10, page: 1, organizationId: 1 } as any,
+        undefined,
+        user
+      );
+
+      expect(orderByCalls).toHaveLength(1);
+      expect(orderByCalls[0][0]).toBe(`"updatedDate"`);
+      expect(orderByCalls[0][1]).toBe("DESC");
+    });
   });
 });

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
@@ -983,16 +983,34 @@ export class CreditTransactionsManagementService {
     } else if (vintagePredicate) {
       qb.where(vintagePredicate.sql, vintagePredicate.params);
     }
-    const resp = await qb
-      .orderBy(
+    const nulls =
+      query?.sort?.nullFirst !== undefined
+        ? query?.sort?.nullFirst === true
+          ? "NULLS FIRST"
+          : "NULLS LAST"
+        : undefined;
+    if (query?.sort?.key === "serialNumber") {
+      // Same fix as queryExplorer: "serialNumber" is a single formatted
+      // string (CA0NNN-NG-XX-{projectId}-{blockStart}-{blockEnd}-{vintage}),
+      // so a plain text ORDER BY sorts it lexicographically. Sort by its
+      // numeric project ID and block start instead.
+      qb.orderBy(
+        this.serialProjectIdNumericExpr("creditTx"),
+        query.sort.order,
+        nulls
+      ).addOrderBy(
+        this.serialRangeStartExpr("creditTx"),
+        query.sort.order,
+        nulls
+      );
+    } else {
+      qb.orderBy(
         query?.sort?.key && `"${query?.sort?.key}"`,
         query?.sort?.order,
-        query?.sort?.nullFirst !== undefined
-          ? query?.sort?.nullFirst === true
-            ? "NULLS FIRST"
-            : "NULLS LAST"
-          : undefined
-      )
+        nulls
+      );
+    }
+    const resp = await qb
       .skip(query.size * query.page - query.size)
       .take(query.size)
       .getManyAndCount();
@@ -1031,18 +1049,35 @@ export class CreditTransactionsManagementService {
       ? query.filterAnd.push(orgFilter)
       : (query.filterAnd = [orgFilter]);
 
-    const resp = await this.creditBlockOrgTransactionsViewEntityRepository
+    const qb = this.creditBlockOrgTransactionsViewEntityRepository
       .createQueryBuilder("orgTx")
-      .where(this.helperService.generateWhereSQL(query, abilityCondition))
-      .orderBy(
+      .where(this.helperService.generateWhereSQL(query, abilityCondition));
+    const order = query?.sort?.order ?? "DESC";
+    const nulls =
+      query?.sort?.nullFirst !== undefined
+        ? query?.sort?.nullFirst === true
+          ? "NULLS FIRST"
+          : "NULLS LAST"
+        : undefined;
+    if (query?.sort?.key === "serialNumber") {
+      // Same fix as queryExplorer/queryIssuances: "serialNumber" is a
+      // single formatted string
+      // (CA0NNN-NG-XX-{projectId}-{blockStart}-{blockEnd}-{vintage}), so a
+      // plain text ORDER BY sorts it lexicographically. Sort by its
+      // numeric project ID and block start instead.
+      qb.orderBy(
+        this.serialProjectIdNumericExpr("orgTx"),
+        order,
+        nulls
+      ).addOrderBy(this.serialRangeStartExpr("orgTx"), order, nulls);
+    } else {
+      qb.orderBy(
         query?.sort?.key ? `"${query?.sort?.key}"` : `"updatedDate"`,
-        query?.sort?.order ?? "DESC",
-        query?.sort?.nullFirst !== undefined
-          ? query?.sort?.nullFirst === true
-            ? "NULLS FIRST"
-            : "NULLS LAST"
-          : undefined
-      )
+        order,
+        nulls
+      );
+    }
+    const resp = await qb
       .skip(query.size * query.page - query.size)
       .take(query.size)
       .getManyAndCount();
@@ -1095,16 +1130,28 @@ export class CreditTransactionsManagementService {
     } else if (serialPredicate) {
       qb.where(serialPredicate.sql, serialPredicate.params);
     }
-    const resp = await qb
-      .orderBy(
+    const nulls =
+      query?.sort?.nullFirst !== undefined
+        ? query?.sort?.nullFirst === true
+          ? "NULLS FIRST"
+          : "NULLS LAST"
+        : undefined;
+    if (query?.sort?.key === "serialNumber") {
+      // "serialNumber" is a single formatted string
+      // (CA0NNN-NG-XX-{projectId}-{blockStart}-{blockEnd}-{vintage}), so a
+      // plain text ORDER BY sorts it lexicographically (e.g. "26" ends up
+      // after "252"). Sort by its numeric segments instead, in the same
+      // left-to-right order they appear in the visible serial number.
+      qb.orderBy(this.serialProjectIdNumericExpr(), query.sort.order, nulls)
+        .addOrderBy(this.serialRangeStartExpr(), query.sort.order, nulls);
+    } else {
+      qb.orderBy(
         query?.sort?.key && `"${query?.sort?.key}"`,
         query?.sort?.order,
-        query?.sort?.nullFirst !== undefined
-          ? query?.sort?.nullFirst === true
-            ? "NULLS FIRST"
-            : "NULLS LAST"
-          : undefined
-      )
+        nulls
+      );
+    }
+    const resp = await qb
       .skip(query.size * query.page - query.size)
       .take(query.size)
       .getManyAndCount();
@@ -1949,8 +1996,8 @@ export class CreditTransactionsManagementService {
     return `(${this.serialRangeStartExpr()} <= :serialHi AND ${this.serialRangeEndExpr()} >= :serialLo)`;
   }
 
-  private serialRangeStartExpr(): string {
-    return `CASE WHEN split_part("creditBlock"."serialNumber", '-', 5) ~ '^[0-9]+$' THEN split_part("creditBlock"."serialNumber", '-', 5)::int END`;
+  private serialRangeStartExpr(alias: string = "creditBlock"): string {
+    return `CASE WHEN split_part("${alias}"."serialNumber", '-', 5) ~ '^[0-9]+$' THEN split_part("${alias}"."serialNumber", '-', 5)::int END`;
   }
 
   private serialRangeEndExpr(): string {
@@ -1963,6 +2010,10 @@ export class CreditTransactionsManagementService {
 
   private serialProjectIdExpr(): string {
     return `split_part("creditBlock"."serialNumber", '-', 4)`;
+  }
+
+  private serialProjectIdNumericExpr(alias: string = "creditBlock"): string {
+    return `CASE WHEN split_part("${alias}"."serialNumber", '-', 4) ~ '^[0-9]+$' THEN split_part("${alias}"."serialNumber", '-', 4)::int END`;
   }
 
   private serialCreditIdExpr(): string {

--- a/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
+++ b/backend/services/libs/shared/src/credit-transactions-management/credit-transactions-management.service.ts
@@ -878,7 +878,9 @@ export class CreditTransactionsManagementService {
       .createQueryBuilder("creditTx")
       .where(this.helperService.generateWhereSQL(query, abilityCondition))
       .orderBy(
-        query?.sort?.key && `"${query?.sort?.key}"`,
+        query?.sort?.key === "id"
+          ? this.idNumericExpr("creditTx")
+          : query?.sort?.key && `"${query?.sort?.key}"`,
         query?.sort?.order,
         query?.sort?.nullFirst !== undefined
           ? query?.sort?.nullFirst === true
@@ -1974,6 +1976,16 @@ export class CreditTransactionsManagementService {
       return null;
     }
     return { sql: `(${conditions.join(" AND ")})`, params };
+  }
+
+  /**
+   * credit_transactions_entity.id is a PrimaryColumn typed as `string`, but
+   * its values are unpadded CounterService-generated integers ("1", "2",
+   * ..., "10", ...), not a naturally sortable text ID - a plain text
+   * ORDER BY puts "10" before "2". Cast it for numeric sort instead.
+   */
+  private idNumericExpr(alias: string): string {
+    return `CASE WHEN "${alias}"."id" ~ '^[0-9]+$' THEN "${alias}"."id"::bigint END`;
   }
 
   /**

--- a/backend/services/libs/shared/src/enum/company.state.enum.ts
+++ b/backend/services/libs/shared/src/enum/company.state.enum.ts
@@ -4,3 +4,13 @@ export enum CompanyState {
     PENDING = '2',
     REJECTED = '3'
 }
+
+// Alphabetical order of each state's displayed label (Active, Deactivated,
+// Pending, Rejected - see organisationStatus.tsx / companyProfile/en.json).
+// Keep in sync when adding a new CompanyState.
+export const COMPANY_STATE_ALPHABETICAL_ORDER: CompanyState[] = [
+    CompanyState.ACTIVE,
+    CompanyState.SUSPENDED,
+    CompanyState.PENDING,
+    CompanyState.REJECTED,
+];

--- a/backend/services/libs/shared/src/user/user.service.spec.ts
+++ b/backend/services/libs/shared/src/user/user.service.spec.ts
@@ -1,18 +1,96 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { UserService } from './user.service';
+import { UserService } from "./user.service";
 
-describe('UserService', () => {
+describe("UserService", () => {
   let service: UserService;
+  let orderByArgs: any[];
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
-    }).compile();
+  beforeEach(() => {
+    orderByArgs = [];
+    const queryBuilder: any = {
+      where: jest.fn().mockReturnThis(),
+      leftJoinAndMapOne: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockImplementation((...args: any[]) => {
+        orderByArgs = args;
+        return queryBuilder;
+      }),
+      offset: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+    const userRepo: any = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    };
+    const helperService: any = {
+      generateWhereSQL: jest.fn(),
+      parseMongoQueryToSQLWithTable: jest.fn(),
+      formatReqMessagesString: jest.fn(),
+    };
 
-    service = module.get<UserService>(UserService);
+    service = new UserService(
+      userRepo,
+      {} as any, // logger
+      {} as any, // configService
+      helperService,
+      {} as any, // entityManger
+      {} as any, // companyService
+      {} as any, // emailHelperService
+      {} as any, // counterService
+      {} as any, // countryService
+      {} as any, // fileHandler
+      {} as any, // asyncOperationsInterface
+      {} as any, // locationService
+      {} as any, // passwordHashService
+      {} as any, // dataExportService
+      {} as any // httpUtilService
+    );
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(service).toBeDefined();
+  });
+
+  describe("query sorting", () => {
+    const user: any = { companyRole: undefined };
+
+    it.each(["companyRole", "role"])(
+      "casts %s to text so it sorts alphabetically instead of by enum ordinal",
+      async (key) => {
+        await service.query(
+          { size: 10, page: 1, sort: { key, order: "ASC" } } as any,
+          undefined,
+          user
+        );
+        expect(orderByArgs[0]).toBe(`"user"."${key}"::text`);
+      }
+    );
+
+    it("keeps unrelated sort keys on the plain-column path (no regression)", async () => {
+      await service.query(
+        { size: 10, page: 1, sort: { key: "name", order: "DESC" } } as any,
+        undefined,
+        user
+      );
+      expect(orderByArgs[0]).toBe(`"user"."name"`);
+    });
+  });
+
+  describe("download sorting", () => {
+    it.each(["companyRole", "role"])(
+      "casts %s to text so it sorts alphabetically instead of by enum ordinal",
+      async (key) => {
+        await service
+          .download({ sort: { key, order: "ASC" } } as any, undefined)
+          .catch(() => {});
+        expect(orderByArgs[0]).toBe(`"user"."${key}"::text`);
+      }
+    );
+
+    it("keeps unrelated sort keys on the plain-column path (no regression)", async () => {
+      await service
+        .download({ sort: { key: "name", order: "DESC" } } as any, undefined)
+        .catch(() => {});
+      expect(orderByArgs[0]).toBe(`"user"."name"`);
+    });
   });
 });

--- a/backend/services/libs/shared/src/user/user.service.ts
+++ b/backend/services/libs/shared/src/user/user.service.ts
@@ -1072,7 +1072,11 @@ export class UserService {
         "company.companyId = user.companyId"
       )
       .orderBy(
-        query?.sort?.key ? `"user"."${query?.sort?.key}"` : `"user"."id"`,
+        query?.sort?.key
+          ? this.isEnumTextSortColumn(query.sort.key)
+            ? `"user"."${query.sort.key}"::text`
+            : `"user"."${query?.sort?.key}"`
+          : `"user"."id"`,
         query?.sort?.order ? query?.sort?.order : "DESC"
       )
       .offset(query.size * query.page - query.size)
@@ -1126,7 +1130,11 @@ export class UserService {
         "company.companyId = user.companyId"
       )
       .orderBy(
-        queryDto?.sort?.key ? `"user"."${queryDto?.sort?.key}"` : `"user"."id"`,
+        queryDto?.sort?.key
+          ? this.isEnumTextSortColumn(queryDto.sort.key)
+            ? `"user"."${queryDto.sort.key}"::text`
+            : `"user"."${queryDto?.sort?.key}"`
+          : `"user"."id"`,
         queryDto?.sort?.order ? queryDto?.sort?.order : "DESC"
       )
       .getMany();
@@ -1415,5 +1423,17 @@ export class UserService {
       this.helperService.formatReqMessagesString(errorMessage, []),
       HttpStatus.BAD_REQUEST
     );
+  }
+
+  /**
+   * "role" and "companyRole" are native Postgres enums (user_role_enum,
+   * user_companyrole_enum), so a plain ORDER BY sorts by declared ordinal
+   * (e.g. Root, Admin, Manager, ViewOnly) rather than alphabetically. Their
+   * enum values are already the exact display strings, so - unlike
+   * company.state - a simple ::text cast is enough; no label-order mapping
+   * needed.
+   */
+  private isEnumTextSortColumn(key: string): boolean {
+    return key === "role" || key === "companyRole";
   }
 }


### PR DESCRIPTION
Root cause analysis:
- Serial numbers are stored as a single formatted string (CA0NNN-NG-XX-{projectId}-{blockStart}-{blockEnd}-{vintage}). queryExplorer, queryIssuances, and queryOrgCreditBlocks each built their ORDER BY as `"${sort.key}"` (or, for queryOrgCreditBlocks, `"${sort.key}"` with an `"updatedDate"` fallback) with no cast/expression, so sorting by "serialNumber" was a plain lexicographic string comparison on all three.
- Since projectId and blockStart are variable-length numbers embedded in the string, string comparison doesn't match numeric order (e.g. "26" sorted after "252", because '5' < '6' at the second character) - confirmed against a screenshot showing rows grouped 252, 252, 252, 26, 26, 26, 268, 273, 273, 273 instead of 26, 252, 268, 273.
-  credit_transactions_entity.id is a PrimaryColumn typed as `string`,
  but its values are unpadded CounterService-generated integers ("1",
  "2", ..., "10"). queryTransfers sorted it as plain text, so "10"
  sorted before "2".
- Company.state and User.role/companyRole are native Postgres ENUM columns. ORDER BY on an enum sorts by declared type ordinal, not alphabetically or by the displayed label:
- company_state_enum declares SUSPENDED(0), ACTIVE(1), PENDING(2), REJECTED(3) - ascending sort put "Deactivated" before "Active".
- user_role_enum declares Root, Admin, Manager, ViewOnly (not alphabetical); user_companyrole_enum declares IC, PD, API, DNA, Ministry, ClimateFund, ExecutiveCommittee (not alphabetical).

Fixes by endpoint:
projectManagement/query 

`projectProposalStage → ::text cast `
`sectoralScope → no query change `needed; fixed at the data level by your WASTE_FROM_FUELS → FUGITIVE_EMISSIONS_FUELS rename, which aligned raw-code order with label order , plus migration 1785825545449 to backfill pre-rename rows
creditTransactionsManagement/queryExplorer, queryIssuances, queryOrgCreditBlocks 

`serialNumber → 2-key numeric ORDER BY on project ID `then block start, reusing the existing split_part() helpers from the Explorer search box (mechanism B). Helpers gained an alias param, since the three methods use different query-builder aliases (creditBlock / creditTx / orgTx)
creditTransactionsManagement/queryTransfers 

`id → regex-guarded ::bigint `cast via idNumericExpr 
organisation/query 

`state → CASE rank from a new COMPANY_STATE_ALPHABETICAL_ORDER list `colocated with the enum, with an ELSE bucket so a future unmapped state sorts last rather than breaking the query. Needed a mapping rather than a cast because the enum's raw values are meaningless digits '0'–'3' 
user/query and the Users CSV export 

`role, companyRole → ::text cast.` A plain cast sufficed here because these enum values already are the display strings 

[Jira Task](https://xeptagon.atlassian.net/browse/UNCR-467?atlOrigin=eyJpIjoiNmU0OWVhNjVmZjFkNDcxYWI1MTYzZmVlYzFhY2JhNjciLCJwIjoiaiJ9)