### PR TITLE
Uncr 450/466 fixes

### DIFF
--- a/web/public/locales/i18n/companyProfile/en.json
+++ b/web/public/locales/i18n/companyProfile/en.json
@@ -41,6 +41,7 @@
     "filterByProject": "Filter by Project",
     "appliedFilters": "Applied Filters",
     "clearAll": "Clear All",
+    "selectAll": "Select All",
     "deauthoriseConfirmHeaderText": "Are you sure you want to deactivate this organisation?",
     "deauthoriseConfirmText":"Organisation will still be visible but no further action will be able to take place.\n Note: all users associated with the organisation will also be deactivated.",
     "activeStatus": "Active",

--- a/web/public/locales/i18n/companyProfile/es.json
+++ b/web/public/locales/i18n/companyProfile/es.json
@@ -48,5 +48,6 @@
   "all": "Todos",
   "filterByProject": "Filtrar por proyecto",
   "appliedFilters": "Filtros aplicados",
-  "clearAll": "Borrar todo"
+  "clearAll": "Borrar todo",
+  "selectAll": "Seleccionar todo"
 }

--- a/web/public/locales/i18n/companyProfile/fr.json
+++ b/web/public/locales/i18n/companyProfile/fr.json
@@ -49,5 +49,6 @@
   "all": "Tous",
   "filterByProject": "Filtrer par projet",
   "appliedFilters": "Filtres appliqués",
-  "clearAll": "Tout effacer"
+  "clearAll": "Tout effacer",
+  "selectAll": "Tout sélectionner"
 }

--- a/web/src/Components/Common/FilterBar/FilterBar.scss
+++ b/web/src/Components/Common/FilterBar/FilterBar.scss
@@ -171,6 +171,31 @@
   .ant-skeleton { width: 100%; }
 }
 
+.filter-bar__dropdown .filter-bar__select-all {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+  padding: 5px 12px;
+  border-bottom: 1px solid #f0f0f0;
+  color: rgba(0, 0, 0, 0.85);
+  font-size: 14px;
+  line-height: 22px;
+  cursor: pointer;
+
+  &:hover { background: #f5f5f5; }
+
+  &--selected {
+    background: #e6f7ff;
+    font-weight: 600;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(24, 144, 255, 0.35);
+    outline-offset: -2px;
+  }
+}
+
 .filter-bar__info-modal {
   .ant-modal-content {
     display: flex;

--- a/web/src/Components/Common/FilterBar/FilterBar.tsx
+++ b/web/src/Components/Common/FilterBar/FilterBar.tsx
@@ -77,6 +77,7 @@ export interface MultiSelectFilterControl extends ControlBase, AsyncSelectContro
   clearValue?: FilterValue[];
   options: FilterOption[];
   onChange?: (value: FilterValue[]) => void;
+  onSelectAll?: () => Promise<FilterOption[]>;
 }
 
 /** A single year picker (e.g. credit vintage) — stores the picked year as a
@@ -129,6 +130,7 @@ export interface FilterBarProps {
   appliedFiltersLabel: ReactNode;
   clearAllLabel: ReactNode;
   onClearAll: () => void;
+  selectAllLabel?: ReactNode;
   showAppliedFilters?: boolean;
   className?: string;
 }
@@ -155,6 +157,7 @@ export const FilterBar = ({
   appliedFiltersLabel,
   clearAllLabel,
   onClearAll,
+  selectAllLabel = "Select All",
   showAppliedFilters = true,
   className = "",
 }: FilterBarProps) => {
@@ -165,6 +168,7 @@ export const FilterBar = ({
   const [overflowExpanded, setOverflowExpanded] = useState(false);
   const [openInfoPopoverId, setOpenInfoPopoverId] = useState<string>();
   const [openInfoDetails, setOpenInfoDetails] = useState<FilterInfoLearnMore>();
+  const [selectAllLoadingId, setSelectAllLoadingId] = useState<string>();
   const visibleRadioConfig = radioGroup?.visible !== false ? radioGroup : undefined;
   const visibleRadio = visibleRadioConfig
     ? { ...visibleRadioConfig, value: values[visibleRadioConfig.id] ?? visibleRadioConfig.clearValue }
@@ -195,6 +199,26 @@ export const FilterBar = ({
   };
   const changeRadio = (value: FilterValue | FilterValue[]) =>
     emitChange(visibleRadio?.id ?? "", value, visibleRadio?.onChange as ((value: never) => void) | undefined);
+  const isAllSelected = (control: MultiSelectFilterControl & { value: FilterValue[] }) =>
+    control.value.length > 0
+    && control.options.length > 0
+    && control.options.every((option) => control.value.includes(option.value));
+  const toggleSelectAll = async (
+    control: MultiSelectFilterControl & { value: FilterValue[] }
+  ) => {
+    const onControlChange = control.onChange as ((value: never) => void) | undefined;
+    if (isAllSelected(control)) {
+      emitChange(control.id, control.clearValue ?? [], onControlChange);
+      return;
+    }
+    setSelectAllLoadingId(control.id);
+    try {
+      const options = (await control.onSelectAll?.()) ?? control.options;
+      emitChange(control.id, options.map((option) => option.value), onControlChange);
+    } finally {
+      setSelectAllLoadingId(undefined);
+    }
+  };
 
   if (
     visibleRadio &&
@@ -666,6 +690,33 @@ export const FilterBar = ({
                         notFoundContent: control.loading ? <Spin size="small" /> : undefined,
                       }
                     : { optionFilterProp: "label" as const })}
+                  {...(control.mode === "multiple" && !(disabled || control.disabled)
+                    ? {
+                        dropdownClassName: "filter-bar__dropdown",
+                        dropdownRender: (menu: ReactNode) => (
+                          <>
+                            <div
+                              className={`filter-bar__select-all${
+                                isAllSelected(control) ? " filter-bar__select-all--selected" : ""
+                              }`}
+                              role="button"
+                              tabIndex={0}
+                              onMouseDown={(event) => event.preventDefault()}
+                              onClick={() => void toggleSelectAll(control)}
+                              onKeyDown={(event) => {
+                                if (event.key !== "Enter" && event.key !== " ") return;
+                                event.preventDefault();
+                                void toggleSelectAll(control);
+                              }}
+                            >
+                              <span>{selectAllLabel}</span>
+                              {selectAllLoadingId === control.id && <Spin size="small" />}
+                            </div>
+                            {menu}
+                          </>
+                        ),
+                      }
+                    : {})}
                   listHeight={control.listHeight}
                   value={control.value}
                   options={control.options}

--- a/web/src/Components/Common/FilterBar/usePaginatedEntityFilter.ts
+++ b/web/src/Components/Common/FilterBar/usePaginatedEntityFilter.ts
@@ -125,7 +125,9 @@ export const usePaginatedEntityFilter = ({
     onDropdownVisibleChange: (open: boolean) => open && select.onDropdownOpen(),
   };
   const control: MultiSelectFilterControl | SingleSelectFilterControl =
-    mode === "multiple" ? { ...base, mode: "multiple" } : { ...base, mode: "single" };
+    mode === "multiple"
+      ? { ...base, mode: "multiple", onSelectAll: select.loadAllOptions }
+      : { ...base, mode: "single" };
 
   return { control, options: select.options, loading: select.loading };
 };

--- a/web/src/Components/Common/FilterBar/usePaginatedSelectOptions.ts
+++ b/web/src/Components/Common/FilterBar/usePaginatedSelectOptions.ts
@@ -10,6 +10,11 @@ const SCROLL_THRESHOLD_PX = 24;
 // `onPopupScroll`) ever appears — each fresh load keeps fetching until it has
 // this many (or the backend is exhausted). A no-op once page size >= this.
 const DEFAULT_MIN_FILL = 10;
+// "Select All" sweeps every page in one go, so it uses a bigger page than
+// scroll paging — a few hundred options then cost a handful of requests
+// rather than dozens. The cap stops a runaway list from selecting forever.
+const SELECT_ALL_PAGE_SIZE = 100;
+const MAX_SELECT_ALL_OPTIONS = 1000;
 
 export interface FetchPageParams {
   search: string;
@@ -40,6 +45,10 @@ export interface PaginatedSelectOptions {
   onPopupScroll: (e: React.UIEvent<HTMLDivElement>) => void;
   /** Fetch page 1 the first time the dropdown opens (lazy initial load). */
   onDropdownOpen: () => void;
+  /** Fetches every remaining page for the current search term and resolves
+   * with the complete option list — backs the dropdown's "Select All", which
+   * can't just take `options` (that holds only the pages loaded so far). */
+  loadAllOptions: () => Promise<FilterOption[]>;
 }
 
 const dedupeByValue = (options: FilterOption[]): FilterOption[] => {
@@ -142,6 +151,47 @@ export const usePaginatedSelectOptions = ({
     resetAndLoad("");
   }, [resetAndLoad]);
 
+  const loadAllOptions = useCallback(async (): Promise<FilterOption[]> => {
+    // Taking over: bumping the token drops whatever page load was in flight,
+    // since this sweep replaces the whole list anyway.
+    requestTokenRef.current += 1;
+    const token = requestTokenRef.current;
+    setLoading(true);
+    loadingRef.current = true;
+    // Sweeping the *current* term is what makes "Select All" mean "all
+    // matches" once the user has typed something.
+    const search = searchRef.current;
+    const collected: FilterOption[] = [];
+    try {
+      for (let page = 1; collected.length < MAX_SELECT_ALL_OPTIONS; page += 1) {
+        const fetched = await fetchPage({ search, page, size: SELECT_ALL_PAGE_SIZE });
+        if (token !== requestTokenRef.current) return []; // superseded
+        collected.push(...fetched);
+        if (fetched.length < SELECT_ALL_PAGE_SIZE) break;
+      }
+      const all = dedupeByValue(collected).slice(0, MAX_SELECT_ALL_OPTIONS);
+      all.forEach((option) => cacheRef.current.set(option.value, option));
+      loadedValuesRef.current = new Set(all.map((option) => option.value));
+      pageRef.current = 0;
+      // Everything (up to the cap) is loaded, so scrolling has nothing left to
+      // fetch until the next search resets paging.
+      hasMoreRef.current = false;
+      initializedRef.current = true;
+      setPageOptions(all);
+      return all;
+    } catch (error) {
+      if (token !== requestTokenRef.current) return [];
+      console.error("Error loading paginated select options", error);
+      hasMoreRef.current = false;
+      return [];
+    } finally {
+      if (token === requestTokenRef.current) {
+        setLoading(false);
+        loadingRef.current = false;
+      }
+    }
+  }, [fetchPage]);
+
   const onSearch = useCallback(
     (text: string) => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -185,5 +235,5 @@ export const usePaginatedSelectOptions = ({
     return dedupeByValue([...selected, ...pageOptions]);
   }, [selectedValues, pageOptions]);
 
-  return { options, loading, onSearch, onPopupScroll, onDropdownOpen };
+  return { options, loading, onSearch, onPopupScroll, onDropdownOpen, loadAllOptions };
 };

--- a/web/src/Components/Company/CompanyProfile/organizationTransactionsTable.tsx
+++ b/web/src/Components/Company/CompanyProfile/organizationTransactionsTable.tsx
@@ -365,6 +365,7 @@ export const OrganizationTransactionsTable = ({
         disabled={loading}
         appliedFiltersLabel={t('appliedFilters')}
         clearAllLabel={t('clearAll')}
+        selectAllLabel={t('selectAll')}
       />
       <div className="credit-table-container">
         <Table

--- a/web/src/Pages/CreditPages/Components/creditBalanceByProjectTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditBalanceByProjectTable.tsx
@@ -10,6 +10,7 @@ import { API_PATHS } from '../../../Config/apiConfig';
 import { useConnection } from '../../../Context/ConnectionContext/connectionContext';
 import { useUserContext } from '../../../Context/UserInformationContext/userInformationContext';
 import { CompanyRole } from '../../../Definitions/Enums/company.role.enum';
+import { Role } from '../../../Definitions/Enums/role.enum';
 import { CreditActionType } from '../Enums/creditActionType.enum';
 import { IssuedOrReceivedOptions } from '../Enums/creditEventEnum';
 import { CreditRetirementProceedAction } from '../Enums/creditRetirementProceedType.enum';
@@ -359,7 +360,8 @@ export const CreditBalanceByProjectTable = ({
   const { post } = useConnection();
   const { userInfoState } = useUserContext();
   const canManageCredits =
-    userInfoState?.companyRole === CompanyRole.PROJECT_DEVELOPER;
+    userInfoState?.companyRole === CompanyRole.PROJECT_DEVELOPER &&
+    userInfoState?.userRole === Role.Admin;
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [rows, setRows] = useState<ProjectBalance[]>([]);

--- a/web/src/Pages/CreditPages/Components/creditBlockList.tsx
+++ b/web/src/Pages/CreditPages/Components/creditBlockList.tsx
@@ -601,6 +601,7 @@ export const CreditBlockListTableComponent = ({ t }: CreditBlockListTableProps) 
         disabled={loading}
         appliedFiltersLabel={t("appliedFilters")}
         clearAllLabel={t("clearAll")}
+        selectAllLabel={t("selectAll")}
       />
       <Row>
         <Col span={24}>

--- a/web/src/Pages/CreditPages/Components/creditIssuanceTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditIssuanceTable.tsx
@@ -386,6 +386,7 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
         disabled={loading}
         appliedFiltersLabel={t("appliedFilters")}
         clearAllLabel={t("clearAll")}
+        selectAllLabel={t("selectAll")}
       />
       <Row>
         <Col span={24}>

--- a/web/src/Pages/CreditPages/creditBalancePage.tsx
+++ b/web/src/Pages/CreditPages/creditBalancePage.tsx
@@ -169,10 +169,10 @@ export const CreditBalancePage = () => {
                   { ...projectFilter.control, width: 280, visible: view === 'project' },
                 ]}
                 onChange={onFilterChange}
-                appliedFiltersLabel="Applied filters"
-                clearAllLabel="Clear all"
+                appliedFiltersLabel={t('appliedFilters')}
+                clearAllLabel={t('clearAll')}
+                selectAllLabel={t('selectAll')}
                 onClearAll={() => setFilterValues({ organizations: [], projects: [] })}
-                showAppliedFilters={false}
               />
             </div>
 

--- a/web/src/Pages/CreditPages/creditPageStyles.scss
+++ b/web/src/Pages/CreditPages/creditPageStyles.scss
@@ -634,15 +634,13 @@
     gap: 10px 16px;
 
     .ant-radio-wrapper {
-      display: inline-flex;
-      align-items: flex-start;
+      align-items: baseline;
       min-width: 0;
       margin: 0;
       color: #475569;
       line-height: 1.4;
       white-space: normal;
 
-      .ant-radio { margin-top: 2px; }
       > span:last-child { min-width: 0; padding-right: 4px; }
     }
   }

--- a/web/src/Pages/CreditPages/creditPageStyles.scss
+++ b/web/src/Pages/CreditPages/creditPageStyles.scss
@@ -276,19 +276,23 @@
   }
 
   .credit-balance-filter-bar {
-    align-self: center;
-    flex: 1 1 520px;
-    max-width: 600px;
-    margin-left: auto;
-    margin-bottom: 0;
-    padding: 0;
-    border: 0;
-    background: transparent;
+    display: contents;
 
-    .filter-bar__toolbar,
+    .filter-bar__toolbar {
+      flex: 1 1 320px;
+      min-width: 0;
+      align-items: center;
+      justify-content: flex-end;
+    }
+
     .filter-bar__controls {
       align-items: center;
       justify-content: flex-end;
+    }
+
+    .filter-bar__applied {
+      flex: 1 1 100%;
+      margin-top: 0;
     }
   }
 
@@ -497,7 +501,6 @@
 
   @media (max-width: 900px) {
     .credit-balance-toolbar { align-items: stretch; }
-    .credit-balance-filter-bar { flex-basis: 100%; max-width: none; margin-left: 0; }
   }
 
   @media (max-width: 600px) {


### PR DESCRIPTION
1. **Restrict credit transfer & retirement to PD Admins** — the Credit Balance page gated on company role only, so PD Managers/Viewers saw the Transfer/Retire actions and hit a 400 on submit. The UI now matches what `credit-transactions-management.service.ts` already enforces.

2. **Applied filters + Clear All on Credit Balance** — the section was disabled (`showAppliedFilters={false}`). Now enabled, matching the Credit Issuance page, with a layout fix so the chips get their own row while the selects stay on the tabs' line.

3. **"Select All" in FilterBar multi-select dropdowns** — since every multi-select is server-paginated, it sweeps the remaining pages for the current search term before selecting, so it means *all* matching options, not just the loaded page. Wired once in `usePaginatedEntityFilter`, so all four consumer pages get it.

4. **Fix retirement-type radio alignment** 
