### PR TITLE
fix: include deactivated orgs in credit page organisation filters

### DIFF
--- a/web/src/Pages/CreditPages/Components/creditBlockList.tsx
+++ b/web/src/Pages/CreditPages/Components/creditBlockList.tsx
@@ -211,7 +211,7 @@ export const CreditBlockListTableComponent = ({ t }: CreditBlockListTableProps) 
   // Org & Project dropdowns load lazily, page-by-page, and search server-side
   // (see usePaginatedEntityFilter) rather than preloading the whole list.
   const orgFilter = usePaginatedEntityFilter({
-    endpoint: API_PATHS.ORGANIZATION_NAMES,
+    endpoint: API_PATHS.ORGANIZATION_DETAILS,
     id: "organization",
     mode: "multiple",
     placeholder: t("filterByOrganization"),
@@ -220,7 +220,7 @@ export const CreditBlockListTableComponent = ({ t }: CreditBlockListTableProps) 
     sortKey: "name",
     extraFilters: [
       { key: "companyRole", operation: "=", value: CompanyRole.PROJECT_DEVELOPER },
-      { key: "state", operation: "=", value: "1" },
+      { key: "state", operation: "in", value: ["0", "1"] },
     ],
     selectedValues: filterValues.organization as FilterValue[],
   });

--- a/web/src/Pages/CreditPages/Components/creditIssuanceTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditIssuanceTable.tsx
@@ -113,7 +113,7 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
   // Org & Project dropdowns load lazily, page-by-page, and search server-side
   // (see usePaginatedEntityFilter) rather than preloading the whole list.
   const orgFilter = usePaginatedEntityFilter({
-    endpoint: API_PATHS.ORGANIZATION_NAMES,
+    endpoint: API_PATHS.ORGANIZATION_DETAILS,
     id: "organization",
     mode: "multiple",
     placeholder: t("filterByOrganization"),
@@ -122,7 +122,7 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
     sortKey: "name",
     extraFilters: [
       { key: "companyRole", operation: "=", value: CompanyRole.PROJECT_DEVELOPER },
-      { key: "state", operation: "=", value: "1" },
+      { key: "state", operation: "in", value: ["0", "1"] },
     ],
     selectedValues: filterValues.organization as FilterValue[],
   });

--- a/web/src/Pages/CreditPages/creditBalancePage.tsx
+++ b/web/src/Pages/CreditPages/creditBalancePage.tsx
@@ -67,7 +67,7 @@ export const CreditBalancePage = () => {
   };
 
   const orgFilter = usePaginatedEntityFilter({
-    endpoint: API_PATHS.ORGANIZATION_NAMES,
+    endpoint: API_PATHS.ORGANIZATION_DETAILS,
     id: 'organizations',
     mode: 'multiple',
     placeholder: t('selectOrganization'),
@@ -76,7 +76,7 @@ export const CreditBalancePage = () => {
     sortKey: 'name',
     extraFilters: [
       { key: 'companyRole', operation: '=', value: CompanyRole.PROJECT_DEVELOPER },
-      { key: 'state', operation: '=', value: '1' },
+      { key: 'state', operation: 'in', value: ['0', '1'] },
     ],
     selectedValues: (filterValues.organizations as FilterValue[]) ?? [],
   });


### PR DESCRIPTION
- Credit page organisation filters now list deactivated orgs alongside active ones
- Switched the org dropdowns on Credit Balance, Issuances, and Block Explorer from `/organisation/queryNames` to `/organisation/query`
- `queryNames` force-ANDs `state = Active`, so the filter had no effect there
- Org filter now sends `state in ('0','1')` — pending/rejected orgs stay excluded

