### PR TITLE
Fix credit table layout: remove sub-table scroll, align columns, center headers

### DIFF
--- a/web/public/locales/i18n/nav/en.json
+++ b/web/public/locales/i18n/nav/en.json
@@ -23,7 +23,7 @@
   "goldStandards": "Gold Standard",
   "cdmTransitionProjects": "CDM Transition Requested Projects",
   "projectList": "Project Details",
-  "creditBalance": "Credit Balance",
+  "creditBalance": "Balance",
   "creditBlockList": "Explorer",
   "issuance": "Issuance",
   "credits": "Credits",

--- a/web/src/Pages/CreditPages/Components/creditBalanceByOrganizationTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditBalanceByOrganizationTable.tsx
@@ -86,11 +86,11 @@ const columns: ColumnsType<OrganizationBalance> = [
       </div>
     ),
   },
-  { title: 'MO Balance', dataIndex: 'moBalance', key: 'moBalance', align: 'left', sorter: (a, b) => a.moBalance - b.moBalance, render: formatCredits },
-  { title: 'MO Reserved', dataIndex: 'moReserved', key: 'moReserved', align: 'left', sorter: (a, b) => a.moReserved - b.moReserved, render: formatCredits },
-  { title: 'ITMO Balance', dataIndex: 'itmoBalance', key: 'itmoBalance', align: 'left', sorter: (a, b) => a.itmoBalance - b.itmoBalance, render: formatCredits },
-  { title: 'ITMO Reserved', dataIndex: 'itmoReserved', key: 'itmoReserved', align: 'left', sorter: (a, b) => a.itmoReserved - b.itmoReserved, render: formatCredits },
-  { title: 'Updated Date & Time', dataIndex: 'updatedAt', key: 'updatedAt', align: 'left', sorter: (a, b) => a.updatedAt.localeCompare(b.updatedAt) },
+  { title: 'MO Balance', dataIndex: 'moBalance', key: 'moBalance', align: 'right', sorter: (a, b) => a.moBalance - b.moBalance, render: formatCredits },
+  { title: 'MO Reserved', dataIndex: 'moReserved', key: 'moReserved', align: 'right', sorter: (a, b) => a.moReserved - b.moReserved, render: formatCredits },
+  { title: 'ITMO Balance', dataIndex: 'itmoBalance', key: 'itmoBalance', align: 'right', sorter: (a, b) => a.itmoBalance - b.itmoBalance, render: formatCredits },
+  { title: 'ITMO Reserved', dataIndex: 'itmoReserved', key: 'itmoReserved', align: 'right', sorter: (a, b) => a.itmoReserved - b.itmoReserved, render: formatCredits },
+  { title: 'Updated Date & Time', dataIndex: 'updatedAt', key: 'updatedAt', align: 'center', sorter: (a, b) => a.updatedAt.localeCompare(b.updatedAt) },
 ];
 
 export const CreditBalanceByOrganizationTable = ({

--- a/web/src/Pages/CreditPages/Components/creditBalanceByProjectTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditBalanceByProjectTable.tsx
@@ -154,15 +154,16 @@ const getSerialColumns = (
   t: (key: string) => string,
   openActions?: (row: CreditSerialBalance) => ReactNode,
 ): ColumnsType<CreditSerialBalance> => [
-  { title: 'Serial Number', dataIndex: 'serialNumber', key: 'serialNumber', align: 'left', width: 280, sorter: (a, b) => a.serialNumber.localeCompare(b.serialNumber), render: (value) => <span className="credit-balance-serial-number">{value}</span> },
-  { title: 'Organization', key: 'organization', align: 'left', sorter: (a, b) => a.organization.localeCompare(b.organization), render: (_, row) => <OrganizationCell name={row.organization} color={row.organizationColor} logo={row.organizationLogo} /> },
-  { title: 'Updated Date & Time', dataIndex: 'updatedAt', key: 'updatedAt', align: 'left', width: 180, sorter: (a, b) => a.updatedAt.localeCompare(b.updatedAt), render: (value) => <span className="credit-balance-detail-date">{value}</span> },
-  { title: 'Balance', dataIndex: 'balance', key: 'balance', align: 'right', sorter: (a, b) => a.balance - b.balance, render: (value) => <span className="credit-balance-detail-number">{formatCredits(value)}</span> },
-  { title: 'Reserved', dataIndex: 'reserved', key: 'reserved', align: 'right', sorter: (a, b) => a.reserved - b.reserved, render: (value) => <span className="credit-balance-detail-number">{formatCredits(value)}</span> },
+  { title: 'Serial Number', dataIndex: 'serialNumber', key: 'serialNumber', align: 'left', width: openActions ? '21%' : '22%', sorter: (a, b) => a.serialNumber.localeCompare(b.serialNumber), render: (value) => <span className="credit-balance-serial-number">{value}</span> },
+  { title: 'Credit Owner', key: 'organization', align: 'left', width: openActions ? '15%' : '16%', sorter: (a, b) => a.organization.localeCompare(b.organization), render: (_, row) => <OrganizationCell name={row.organization} color={row.organizationColor} logo={row.organizationLogo} /> },
+  { title: 'Updated Date & Time', dataIndex: 'updatedAt', key: 'updatedAt', align: 'center', width: openActions ? '15%' : '16%', sorter: (a, b) => a.updatedAt.localeCompare(b.updatedAt), render: (value) => <span className="credit-balance-detail-date">{value}</span> },
+  { title: 'Balance', dataIndex: 'balance', key: 'balance', align: 'right', width: openActions ? '10%' : '11%', sorter: (a, b) => a.balance - b.balance, render: (value) => <span className="credit-balance-detail-number">{formatCredits(value)}</span> },
+  { title: 'Reserved', dataIndex: 'reserved', key: 'reserved', align: 'right', width: openActions ? '10%' : '11%', sorter: (a, b) => a.reserved - b.reserved, render: (value) => <span className="credit-balance-detail-number">{formatCredits(value)}</span> },
   {
     title: t('creditType'),
     key: 'creditType',
     align: 'center',
+    width: openActions ? '10%' : '11%',
     sorter: (a, b) => Number(!!a.itmoAuthorizationRecord) - Number(!!b.itmoAuthorizationRecord),
     render: (_, row) => (
       <CreditTypePill
@@ -177,6 +178,7 @@ const getSerialColumns = (
     dataIndex: 'type',
     key: 'type',
     align: 'center',
+    width: openActions ? '15%' : '13%',
     sorter: (a, b) => a.type.localeCompare(b.type),
     render: (value: IssuedOrReceivedOptions) => (
       <Tag color={value === IssuedOrReceivedOptions.RECEIVED ? 'success' : 'processing'}>
@@ -188,7 +190,7 @@ const getSerialColumns = (
     title: '',
     key: 'action',
     align: 'center' as const,
-    width: 90,
+    width: '4%',
     render: (_value: unknown, row: CreditSerialBalance) => openActions(row),
   }] : []),
 ];
@@ -349,9 +351,7 @@ const CreditBalanceSerialTable = ({
         pagination={false}
         tableLayout="fixed"
         loading={loading && rows.length === 0}
-        scroll={openActions
-          ? { x: 1080, y: SERIAL_BODY_HEIGHT }
-          : { x: 1030, y: SERIAL_BODY_HEIGHT }}
+        scroll={{ y: SERIAL_BODY_HEIGHT }}
       />
       {loading && rows.length > 0 && (
         <div className="credit-balance-serial-loading" aria-label="Loading more credit balances">
@@ -381,11 +381,11 @@ const columns: ColumnsType<ProjectBalance> = [
     ),
   },
   { title: 'Project Owner', key: 'owner', align: 'left', sorter: (a, b) => a.owner.localeCompare(b.owner), render: (_, row) => <OrganizationCell name={row.owner} color={row.ownerColor} logo={row.ownerLogo} /> },
-  { title: 'MO Balance', dataIndex: 'moBalance', key: 'moBalance', align: 'left', sorter: (a, b) => a.moBalance - b.moBalance, render: formatCredits },
-  { title: 'MO Reserved', dataIndex: 'moReserved', key: 'moReserved', align: 'left', sorter: (a, b) => a.moReserved - b.moReserved, render: formatCredits },
-  { title: 'ITMO Balance', dataIndex: 'itmoBalance', key: 'itmoBalance', align: 'left', sorter: (a, b) => a.itmoBalance - b.itmoBalance, render: formatCredits },
-  { title: 'ITMO Reserved', dataIndex: 'itmoReserved', key: 'itmoReserved', align: 'left', sorter: (a, b) => a.itmoReserved - b.itmoReserved, render: formatCredits },
-  { title: 'Updated Date & Time', dataIndex: 'updatedAt', key: 'updatedAt', align: 'left', sorter: (a, b) => a.updatedAt.localeCompare(b.updatedAt) },
+  { title: 'MO Balance', dataIndex: 'moBalance', key: 'moBalance', align: 'right', sorter: (a, b) => a.moBalance - b.moBalance, render: formatCredits },
+  { title: 'MO Reserved', dataIndex: 'moReserved', key: 'moReserved', align: 'right', sorter: (a, b) => a.moReserved - b.moReserved, render: formatCredits },
+  { title: 'ITMO Balance', dataIndex: 'itmoBalance', key: 'itmoBalance', align: 'right', sorter: (a, b) => a.itmoBalance - b.itmoBalance, render: formatCredits },
+  { title: 'ITMO Reserved', dataIndex: 'itmoReserved', key: 'itmoReserved', align: 'right', sorter: (a, b) => a.itmoReserved - b.itmoReserved, render: formatCredits },
+  { title: 'Updated Date & Time', dataIndex: 'updatedAt', key: 'updatedAt', align: 'center', sorter: (a, b) => a.updatedAt.localeCompare(b.updatedAt) },
 ];
 
 export const CreditBalanceByProjectTable = ({
@@ -735,7 +735,6 @@ export const CreditBalanceByProjectTable = ({
         columns={columns}
         loading={loading}
         tableLayout="fixed"
-        scroll={{ x: 1250 }}
         onChange={(_pagination, _filters, _sorter, extra) => {
           if (extra.action === 'sort' && expandedProjectId) {
             toggleExpandedProject(expandedProjectId, true);

--- a/web/src/Pages/CreditPages/Components/creditBlockList.tsx
+++ b/web/src/Pages/CreditPages/Components/creditBlockList.tsx
@@ -403,26 +403,18 @@ export const CreditBlockListTableComponent = ({ t }: CreditBlockListTableProps) 
       title: t(CreditBlockColumns.CREDITS),
       key: "balance",
       sorter: true,
-      align: "left" as const,
+      align: "right" as const,
       render: (record: CreditBlockInterface) => {
-        return (
-          <span style={{ marginLeft: "20px" }}>
-            {addCommSep(String(record?.creditBalance))}
-          </span>
-        );
+        return <span>{addCommSep(String(record?.creditBalance))}</span>;
       },
     },
     {
       title: t(CreditBlockColumns.RESERVED),
       key: "reserved",
       sorter: true,
-      align: "left" as const,
+      align: "right" as const,
       render: (record: CreditBlockInterface) => {
-        return (
-          <span style={{ marginLeft: "20px" }}>
-            {addCommSep(String(record?.reserved ?? 0))}
-          </span>
-        );
+        return <span>{addCommSep(String(record?.reserved ?? 0))}</span>;
       },
     },
     {
@@ -477,7 +469,7 @@ export const CreditBlockListTableComponent = ({ t }: CreditBlockListTableProps) 
       title: t(CreditBlockColumns.UPDATE_DATE),
       key: "updatedTime",
       sorter: true,
-      align: "left" as const,
+      align: "center" as const,
       render: (item: CreditBlockInterface) => {
         return (
           <span>

--- a/web/src/Pages/CreditPages/Components/creditIssuanceTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditIssuanceTable.tsx
@@ -281,7 +281,7 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
       title: t(CreditIssuanceColumns.ISSUANCE_DATE),
       key: "issuanceDate",
       sorter: true,
-      align: "left" as const,
+      align: "center" as const,
       render: (record: CreditIssuanceInterface) => {
         return <span>{moment(Number(record?.issuanceDate)).format("YYYY-MM-DD HH:mm:ss")}</span>;
       },
@@ -290,13 +290,9 @@ export const CreditIssuanceTableComponent = ({ t }: CreditIssuanceTableProps) =>
       title: t(CreditIssuanceColumns.CREDITS),
       key: "creditAmount",
       sorter: true,
-      align: "left" as const,
+      align: "right" as const,
       render: (record: CreditIssuanceInterface) => {
-        return (
-          <span style={{ marginLeft: "20px" }}>
-            {addCommSep(String(record?.creditAmount))}
-          </span>
-        );
+        return <span>{addCommSep(String(record?.creditAmount))}</span>;
       },
     },
     {

--- a/web/src/Pages/CreditPages/Components/creditRetirementsTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditRetirementsTable.tsx
@@ -331,7 +331,7 @@ export const CreditRetirementsTableComponent = (props: any) => {
       title: t(CrediRetirementsColumns.DATE),
       key: "createdDate",
       sorter: true,
-      align: "left" as const,
+      align: "center" as const,
       render: (item: CreditRetirementInterface) => {
         return (
           <span>
@@ -345,13 +345,9 @@ export const CreditRetirementsTableComponent = (props: any) => {
     {
       title: t(CrediRetirementsColumns.CREDITS),
       key: CrediRetirementsColumns.CREDITS,
-      align: "left" as const,
+      align: "right" as const,
       render: (item: CreditRetirementInterface) => {
-        return (
-          <span style={{ marginLeft: "20px" }}>
-            {addCommSep(String(item?.creditAmount))}
-          </span>
-        );
+        return <span>{addCommSep(String(item?.creditAmount))}</span>;
       },
     },
     {

--- a/web/src/Pages/CreditPages/Components/creditTransfersTable.tsx
+++ b/web/src/Pages/CreditPages/Components/creditTransfersTable.tsx
@@ -148,7 +148,7 @@ export const CreditTransfersTableComponent = (props: any) => {
       title: t(CrediTransferColumns.DATE),
       key: "createdDate",
       sorter: true,
-      align: "left" as const,
+      align: "center" as const,
       render: (item: CreditTransfersInterface) => {
         return (
           <span>
@@ -208,13 +208,9 @@ export const CreditTransfersTableComponent = (props: any) => {
     {
       title: t(CrediTransferColumns.CREDIT_TRANSFERRED),
       key: CrediTransferColumns.CREDIT_TRANSFERRED,
-      align: "left" as const,
+      align: "right" as const,
       render: (item: CreditTransfersInterface) => {
-        return (
-          <span style={{ marginLeft: "20px" }}>
-            {addCommSep(String(item?.creditAmount))}
-          </span>
-        );
+        return <span>{addCommSep(String(item?.creditAmount))}</span>;
       },
     },
     ...(userInfoState?.companyRole === CompanyRole.PROJECT_DEVELOPER

--- a/web/src/Pages/CreditPages/Components/itmoAuthorizationsTable.tsx
+++ b/web/src/Pages/CreditPages/Components/itmoAuthorizationsTable.tsx
@@ -328,7 +328,7 @@ export const CreditItmoAuthorizationsTableComponent = (props: any) => {
       title: t(CreditItmoAuthColumns.DATE),
       key: "createdDate",
       sorter: true,
-      align: "left" as const,
+      align: "center" as const,
       render: (item: CreditItmoAuthorizationInterface) => {
         return (
           <span>
@@ -342,13 +342,9 @@ export const CreditItmoAuthorizationsTableComponent = (props: any) => {
     {
       title: t(CreditItmoAuthColumns.CREDITS),
       key: CreditItmoAuthColumns.CREDITS,
-      align: "left" as const,
+      align: "right" as const,
       render: (item: CreditItmoAuthorizationInterface) => {
-        return (
-          <span style={{ marginLeft: "20px" }}>
-            {addCommSep(String(item?.creditAmount))}
-          </span>
-        );
+        return <span>{addCommSep(String(item?.creditAmount))}</span>;
       },
     },
     {

--- a/web/src/Pages/CreditPages/creditPageStyles.scss
+++ b/web/src/Pages/CreditPages/creditPageStyles.scss
@@ -397,7 +397,7 @@
       padding: 11px 16px;
       border-bottom: 0;
       color: variables.$body-text-color !important;
-      white-space: nowrap;
+      overflow: hidden;
     }
 
     .ant-table-tbody > tr > td {
@@ -406,6 +406,7 @@
       background: variables.$white;
       border-bottom: 1px solid variables.$sep-line-color;
       vertical-align: middle;
+      overflow: hidden;
       transition: background-color 160ms ease;
     }
 
@@ -423,14 +424,6 @@
         font-size: 0.75rem;
         line-height: 28px;
       }
-    }
-  }
-
-  .credit-balance-serial-table--with-actions {
-    .ant-table-thead > tr > th:last-child,
-    .ant-table-tbody > tr > td:last-child {
-      min-width: 90px;
-      width: 90px;
     }
   }
 

--- a/web/src/Styles/common.table.scss
+++ b/web/src/Styles/common.table.scss
@@ -9,7 +9,26 @@
         color: variables.$title-text-color;
         font-weight: 600;
         font-size: 0.8rem;
-        text-align: center;
+        text-align: center !important;
+      }
+
+      // The sorter icon sits inside the flex row next to the title, which
+      // shifts the (flex: 1) title's own center away from the column's true
+      // center. Taking it out of flow lets the title center against the
+      // full column width instead. Equal left/right padding keeps that
+      // centering symmetric and reserves clearance so long titles don't
+      // run into the icon on narrower columns.
+      .ant-table-column-sorters {
+        position: relative;
+        padding: 0 22px;
+      }
+
+      .ant-table-column-sorter {
+        position: absolute;
+        top: 50%;
+        right: 0;
+        margin-left: 0;
+        transform: translateY(-50%);
       }
     }
     .ant-table-tbody {


### PR DESCRIPTION
- Remove forced scroll.x on project balance table and its expanded
  serial-number sub-table so they fit the container instead of
  clipping/scrolling on laptop screens
- Right-align balance/reserved/credit amount columns across credit
  balance, issuance, retirement, transfer, ITMO auth, and block tables
- Center date/timestamp columns and rename Organization to Credit Owner
  in the credit balance sub-table
- Center table headers app-wide and fix sorter icon overlap with
  wrapped header text
