### PR TITLE
feat(web): source AEF Party from cooperative approach host party

### DIFF
--- a/web/src/Components/Reporting/ReportingComponent.scss
+++ b/web/src/Components/Reporting/ReportingComponent.scss
@@ -53,6 +53,30 @@
       flex-wrap: wrap;
       row-gap: 8px;
     }
+
+    /* Matches FilterBar's checked-state colors: a solid dark "all" toggle,
+       distinct from the individual options' checked color. */
+    .ant-checkbox-checked .ant-checkbox-inner {
+      border-color: #16a500;
+      background-color: #16a500;
+    }
+
+    .all-check {
+      margin-right: 10px;
+
+      .ant-checkbox-inner::after {
+        background-color: rgba(58, 53, 65, 0.5);
+      }
+
+      .ant-checkbox-checked .ant-checkbox-inner::after {
+        background-color: transparent;
+      }
+
+      .ant-checkbox-checked .ant-checkbox-inner {
+        background-color: rgba(58, 53, 65, 0.5);
+        border: none;
+      }
+    }
   }
 }
 
@@ -73,6 +97,18 @@
     font-weight: 600;
 
     font-size: 14px;
+  }
+
+  /*
+   * `.layout-content-container .ant-btn-primary` (app.scss) forces the brand
+   * color with `!important` regardless of state, which otherwise hides the
+   * disabled look on the submit-row button. Restated here to win back the
+   * standard antd disabled gray.
+   */
+  .ant-btn-primary[disabled] {
+    background-color: #f5f5f5 !important;
+    border-color: #d9d9d9 !important;
+    color: rgba(0, 0, 0, 0.25) !important;
   }
 
   .header-row {

--- a/web/src/Components/Reporting/ReportingComponent.tsx
+++ b/web/src/Components/Reporting/ReportingComponent.tsx
@@ -22,7 +22,6 @@ import {
 } from "./reportTypes";
 import { useConnection } from "../../Context/ConnectionContext/connectionContext";
 import { API_PATHS } from "../../Config/apiConfig";
-import { AEF_CONFIG } from "../../Config/aefConfig";
 import { Loading } from "../Loading/loading";
 import { TimedPageInfoTitle } from "../Common/TimedPageInfoTitle/TimedPageInfoTitle";
 
@@ -69,7 +68,7 @@ const ReportingComponent = (props: { translator: i18n }) => {
   const { translator } = props;
   const t = translator.t;
 
-  const { post } = useConnection();
+  const { get, post } = useConnection();
 
   const [selectedYear, setSelectedYear] = useState<Moment>(moment());
   const [selectedReports, setSelectedReports] = useState<REPORT_TYPES[]>([
@@ -78,8 +77,26 @@ const ReportingComponent = (props: { translator: i18n }) => {
   const [tableState, setTableState] = useState<Record<string, TableState>>(initialTableState);
   const [submitTarget, setSubmitTarget] = useState<Record<string, unknown> | undefined>();
   const [submitting, setSubmitting] = useState(false);
+  const [partyName, setPartyName] = useState<string>();
 
   const reportedYear = selectedYear.year();
+
+  /**
+   * The reporting Party's display name, e.g. `"Nigeria"` for host party `NG`.
+   * Read from the cooperative approach host party rather than an env var, so
+   * it reflects this deployment's actual registry data.
+   */
+  useEffect(() => {
+    (async () => {
+      try {
+        const response = await get(API_PATHS.AEF_HOST_PARTY);
+        setPartyName(response?.data?.name);
+      } catch (error) {
+        console.error("Failed to load AEF host party", error);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /**
    * Holdings for a year that has not been snapshotted are live and still
@@ -217,7 +234,7 @@ const ReportingComponent = (props: { translator: i18n }) => {
       title={t(`reporting:${type}`)}
       reportType={type}
       /* Submission carries Party and Reported year as columns already. */
-      party={type === REPORT_TYPES.SUBMISSION ? undefined : AEF_CONFIG.party}
+      party={type === REPORT_TYPES.SUBMISSION ? undefined : partyName ?? "-"}
       year={type === REPORT_TYPES.SUBMISSION ? undefined : reportedYear}
       provisional={type === REPORT_TYPES.HOLDINGS && holdingsProvisional}
       columns={
@@ -278,6 +295,7 @@ const ReportingComponent = (props: { translator: i18n }) => {
       */}
       <Row className="report-type-checkboxes">
         <Checkbox
+          className="all-check"
           indeterminate={someSelected}
           checked={allSelected}
           onChange={(e) =>

--- a/web/src/Components/Reporting/reportingColumns.ts
+++ b/web/src/Components/Reporting/reportingColumns.ts
@@ -120,7 +120,7 @@ const submitActionCol = (t: Translate, onSubmit: (row: Record<string, unknown>) 
   title: t("reporting:actionsColumn"),
   key: "rowActions",
   fixed: "right" as const,
-  width: 140,
+  width: 100,
   render: (_value: unknown, row: Record<string, unknown>) =>
     createElement(
       Button,
@@ -128,8 +128,12 @@ const submitActionCol = (t: Translate, onSubmit: (row: Record<string, unknown>) 
         type: "primary",
         size: "small",
         // Only a draft can be filed. A submitted or superseded row has already
-        // had its moment, and re-filing is a revision, not a submit.
-        disabled: row.status !== "DRAFT",
+        // had its moment, and re-filing is a revision, not a submit. The
+        // reported year also has to be over — the current year's AEF cannot
+        // be filed until next year, so it stays disabled even while DRAFT.
+        disabled:
+          row.status !== "DRAFT" ||
+          Number(row.aefT1SubmissionReportYear) >= new Date().getFullYear(),
         onClick: () => onSubmit(row),
       },
       t("reporting:submitAef")
@@ -153,7 +157,10 @@ export const getSubmissionReportColumns = (
   carpCol(t, "referenceToTerReport", "aefT1SubmissionReferenceReviewReport", 260),
   statusCol(t),
   ...(onSubmit ? [submitActionCol(t, onSubmit)] : []),
-];
+  // Submission-only: centers cell values while leaving the headers left-aligned.
+  // `align` would center both, so this sets the body cell's style directly
+  // instead. The other four tables keep the default left alignment.
+].map((column) => ({ ...column, onCell: () => ({ style: { textAlign: "center" } }) }));
 
 // ---------------------------------------------------------------------------
 // Table 2 — Authorizations (19 fields)

--- a/web/src/Config/aefConfig.ts
+++ b/web/src/Config/aefConfig.ts
@@ -4,16 +4,12 @@
  * Per-country deployment setting, so it belongs here alongside the other
  * customisation touchpoints rather than being hardcoded in a component.
  *
- * The Party value replaces the `"Sri Lanka"` literal the V1 report cards
- * carried. That was wrong twice over: it hardcoded one deployment into a
- * toolkit meant to be deployed per country, and it used a display name where
- * the AEF requires an **ISO 3166-1 alpha-3 code** (Common Nomenclature Table 1 —
- * `LKA`, `VUT`, `CHE`, plus exceptionally reserved codes such as `EUE`).
+ * The reporting Party's display name is **not** configured here: it is read
+ * from `national/cooperativeApproach/hostParty` at runtime (see
+ * `ReportingComponent`), because that endpoint is the registry's actual
+ * source of truth for which country this deployment represents.
  */
 export const AEF_CONFIG = {
-  /** ISO 3166-1 alpha-3 code of the reporting Party. */
-  party: import.meta.env.VITE_AEF_PARTY ?? "VUT",
-
   /**
    * Party ITMO registry identifier — alpha-3 code plus a two-digit registry
    * number (Common Nomenclature Table 28).

--- a/web/src/Config/apiConfig.ts
+++ b/web/src/Config/apiConfig.ts
@@ -179,5 +179,6 @@ export const API_PATHS = {
   POPUP_ACTION: (endpoint: string) => `national/programme/${endpoint}`,
   // AEF RECORDS:
   QUERY_AEF_RECORDS: `national/reportsManagement/queryAefRecords`,
-  DOWNLOAD_AEF_RECORDS: `national/reportsManagement/downloadAefReport`
+  DOWNLOAD_AEF_RECORDS: `national/reportsManagement/downloadAefReport`,
+  AEF_HOST_PARTY: `national/cooperativeApproach/hostParty`
 };


### PR DESCRIPTION
Replaces the VITE_AEF_PARTY env var with a live lookup: the reporting Party's display name now comes from national/cooperativeApproach/hostParty (response.data.name), fetched once when the Reporting page mounts and threaded through to the four non-Submission report cards.