### PR TITLE
AEF V2: fix the authorized timeframe, and show action dates as dates

### DIFF
--- a/backend/services/libs/shared/src/aef-v2-registry/aef-v2-report.service.spec.ts
+++ b/backend/services/libs/shared/src/aef-v2-registry/aef-v2-report.service.spec.ts
@@ -1,0 +1,82 @@
+import { AefV2ReportService } from "./aef-v2-report.service";
+
+/**
+ * `query` is the reporting tables' read path. It shapes Table 3's Action date
+ * for display without touching what is stored or exported - see the service's
+ * `forDisplay` docblock for why the two must differ.
+ *
+ * The service is constructed with stubs for everything except the store, which
+ * is the only dependency `loadSubmissionBundle` actually reaches for here.
+ */
+describe("AefV2ReportService query display shaping", () => {
+  const defaults = {
+    aefT1SubmissionParty: "NGA",
+    aefT1SubmissionNdcFirstYear: 2021,
+    aefT1SubmissionNdcLastYear: 2030,
+  };
+
+  const buildService = (actions: Record<string, unknown>[]) => {
+    const service = new AefV2ReportService(
+      {} as any, // storeFactory
+      defaults as any,
+      {} as any, // holdings
+      {} as any, // authorizedEntities
+      {} as any, // fileHandler
+      {} as any, // controlledValues
+      {} as any // countryService
+    );
+    // Stubbed at the bundle boundary: the shaping under test happens after it,
+    // and a real bundle would need the whole store/provider stack.
+    (service as any).loadBundle = jest.fn().mockResolvedValue({
+      submission: undefined,
+      authorizations: [],
+      actions,
+      holdings: [],
+      authorizedEntities: [],
+      provisional: { holdings: false, authorizedEntities: false },
+      snapshotAt: { holdings: undefined, authorizedEntities: undefined },
+    });
+    return service;
+  };
+
+  it("shows Table 3's Action date as dd/mm/yyyy, not the stored ISO datetime", async () => {
+    const service = buildService([
+      { aefT3ActionsDate: "2026-08-11T12:14:03.356Z", aefT3ActionsType: "First transfer" },
+    ]);
+
+    const result = await service.query("t3Actions", 2026);
+
+    expect(result.data[0]).toMatchObject({
+      aefT3ActionsDate: "11/08/2026",
+      aefT3ActionsType: "First transfer",
+    });
+  });
+
+  /**
+   * The stored instant is UTC. A late-evening UTC action must not display as
+   * the next day just because the server sits east of Greenwich.
+   */
+  it("takes the day from the UTC instant, not the server's timezone", async () => {
+    const service = buildService([{ aefT3ActionsDate: "2026-08-11T23:45:00.000Z" }]);
+
+    const result = await service.query("t3Actions", 2026);
+
+    expect(result.data[0]).toMatchObject({ aefT3ActionsDate: "11/08/2026" });
+  });
+
+  it("passes a value through untouched when it is not a parseable date", async () => {
+    const service = buildService([{ aefT3ActionsDate: "not a date" }]);
+
+    const result = await service.query("t3Actions", 2026);
+
+    expect(result.data[0]).toMatchObject({ aefT3ActionsDate: "not a date" });
+  });
+
+  it("leaves other tables alone", async () => {
+    const service = buildService([]);
+
+    const result = await service.query("t2Authorizations", 2026);
+
+    expect(result.data).toEqual([]);
+  });
+});

--- a/backend/services/libs/shared/src/aef-v2-registry/aef-v2-report.service.ts
+++ b/backend/services/libs/shared/src/aef-v2-registry/aef-v2-report.service.ts
@@ -5,6 +5,7 @@ import {
   AefTableName,
   AuthorizedEntitiesProvider,
   exportFileName,
+  formatSubmissionDate,
   HoldingsProvider,
   loadSubmissionBundle,
   openReportingYear,
@@ -86,7 +87,7 @@ export class AefV2ReportService {
     const bundle = await this.loadBundle(reportedYear);
     const exportData = toAefSubmissionExport(bundle);
     return {
-      data: exportData[table] ?? [],
+      data: this.forDisplay(table, exportData[table] ?? []),
       provisional:
         table === "t4Holdings"
           ? bundle.provisional.holdings
@@ -100,6 +101,38 @@ export class AefV2ReportService {
             ? bundle.snapshotAt.authorizedEntities
             : undefined,
     };
+  }
+
+  /**
+   * Presentation shaping for the reporting tables, applied on the read path
+   * only — `download` deliberately does not call this.
+   *
+   * Table 3's Action date is stored as an ISO 8601 UTC datetime, which is what
+   * the AEF requires (`field-spec.ts` types it `datetime`, and `recordAction`
+   * derives the reporting year by parsing it), so the stored value and the CARP
+   * export keep the time. On screen it reads as the day alone, matching Table
+   * 2's Date of authorization, which the mapper already stores as `dd/mm/yyyy`.
+   *
+   * `formatSubmissionDate` is UTC-based, so the day shown is the day the action
+   * carries rather than the server's local rendering of that instant.
+   */
+  private forDisplay(table: AefTableName, rows: readonly Record<string, unknown>[]) {
+    if (table !== "t3Actions") {
+      return rows;
+    }
+    return rows.map((row) => {
+      const actionDate = row.aefT3ActionsDate;
+      if (typeof actionDate !== "string") {
+        return row;
+      }
+      const parsed = new Date(actionDate);
+      // A value that is not a parseable date is passed through untouched
+      // rather than turned into "NaN/NaN/NaN".
+      if (Number.isNaN(parsed.getTime())) {
+        return row;
+      }
+      return { ...row, aefT3ActionsDate: formatSubmissionDate(parsed) };
+    });
   }
 
   async validate(reportedYear: number) {

--- a/backend/services/libs/shared/src/aef-v2-registry/mappers/aef-authorization.mapper.spec.ts
+++ b/backend/services/libs/shared/src/aef-v2-registry/mappers/aef-authorization.mapper.spec.ts
@@ -62,9 +62,56 @@ describe("mapItmoAuthorizationToAefAuthorization", () => {
     expect(result.aefT2AuthorizationsAuthorizedTimeframe).toBe("2024 - 2030");
   });
 
-  it("leaves the authorized timeframe blank when either year is missing", () => {
+  // Only a complete range is a valid timeframe - AUTHORIZED_TIMEFRAME_PATTERN
+  // is `dddd - dddd`, so a lone year would be stored only to be rejected on
+  // format at filing time.
+  it("leaves the authorized timeframe unset when only the start year is given", () => {
     const result = mapItmoAuthorizationToAefAuthorization(
       baseInput({ authorizedTimeframeStartYear: 2024, authorizedTimeframeEndYear: undefined }),
+      "01/01/2026"
+    );
+
+    expect(result.aefT2AuthorizationsAuthorizedTimeframe).toBeUndefined();
+  });
+
+  it("leaves the authorized timeframe unset when only the end year is given", () => {
+    const result = mapItmoAuthorizationToAefAuthorization(
+      baseInput({ authorizedTimeframeStartYear: undefined, authorizedTimeframeEndYear: 2030 }),
+      "01/01/2026"
+    );
+
+    expect(result.aefT2AuthorizationsAuthorizedTimeframe).toBeUndefined();
+  });
+
+  it("leaves the authorized timeframe unset when neither year is given", () => {
+    const result = mapItmoAuthorizationToAefAuthorization(
+      baseInput({ authorizedTimeframeStartYear: undefined, authorizedTimeframeEndYear: undefined }),
+      "01/01/2026"
+    );
+
+    expect(result.aefT2AuthorizationsAuthorizedTimeframe).toBeUndefined();
+  });
+
+  // The regression: antd's InputNumber yields null for a cleared field, and the
+  // old `!== undefined` guard let that through as the literal "null - null".
+  it("treats cleared years (null) as absent rather than stringifying them", () => {
+    const result = mapItmoAuthorizationToAefAuthorization(
+      baseInput({
+        authorizedTimeframeStartYear: null as unknown as number,
+        authorizedTimeframeEndYear: null as unknown as number,
+      }),
+      "01/01/2026"
+    );
+
+    expect(result.aefT2AuthorizationsAuthorizedTimeframe).toBeUndefined();
+  });
+
+  it("treats a single cleared year as an incomplete range, not a lone year", () => {
+    const result = mapItmoAuthorizationToAefAuthorization(
+      baseInput({
+        authorizedTimeframeStartYear: null as unknown as number,
+        authorizedTimeframeEndYear: 2030,
+      }),
       "01/01/2026"
     );
 

--- a/backend/services/libs/shared/src/aef-v2-registry/mappers/aef-authorization.mapper.ts
+++ b/backend/services/libs/shared/src/aef-v2-registry/mappers/aef-authorization.mapper.ts
@@ -51,6 +51,35 @@ export interface AefAuthorizationMapperInput {
   creditBlockId: string;
 }
 
+/**
+ * Composes Table 2's Authorized timeframe from the two years the request popup
+ * captures. Emitted only when **both** years are present.
+ *
+ * Both years are optional and independently editable (see itmoAuthRequestModal),
+ * and antd's InputNumber yields **null** for a cleared field rather than
+ * dropping the key — so an earlier `!== undefined` guard let a cleared pair
+ * through and stored the literal string "null - null". Anything that is not a
+ * year is treated as absent here.
+ *
+ * A half-filled timeframe yields nothing rather than the surviving year alone:
+ * AUTHORIZED_TIMEFRAME_PATTERN is `dddd - dddd`, so a lone year would be stored
+ * as a value validateSubmission then rejects on format, blocking the filing
+ * over a field the AEF marks optional. Absent is both valid and honest.
+ *
+ * Never "-": the stored value feeds the CARP workbook and the CSV, where a
+ * literal dash would be data. The dash is a UI affordance — see
+ * reportingColumns.ts.
+ */
+function formatAuthorizedTimeframe(
+  startYear?: number,
+  endYear?: number
+): string | undefined {
+  if (!Number.isFinite(startYear) || !Number.isFinite(endYear)) {
+    return undefined;
+  }
+  return `${startYear} - ${endYear}`;
+}
+
 export function mapItmoAuthorizationToAefAuthorization(
   input: AefAuthorizationMapperInput,
   authorizationDateDdMmYyyy: string
@@ -84,11 +113,10 @@ export function mapItmoAuthorizationToAefAuthorization(
     aefT2AuthorizationsOimpAuthorizedParty: isOimp
       ? TOWARDS_COOPERATIVE_APPROACH_ENTITIES_LABEL
       : NOT_APPLICABLE,
-    aefT2AuthorizationsAuthorizedTimeframe:
-      input.authorizedTimeframeStartYear !== undefined &&
-      input.authorizedTimeframeEndYear !== undefined
-        ? `${input.authorizedTimeframeStartYear} - ${input.authorizedTimeframeEndYear}`
-        : undefined,
+    aefT2AuthorizationsAuthorizedTimeframe: formatAuthorizedTimeframe(
+      input.authorizedTimeframeStartYear,
+      input.authorizedTimeframeEndYear
+    ),
     aefT2AuthorizationsAuthorizationTerms: AUTHORIZATION_TERMS_LABEL,
     aefT2AuthorizationsFirstTransferDefinitionOimp: isOimp
       ? FIRST_TRANSFER_DEFINITION_OIMP_LABEL

--- a/web/public/locales/i18n/reporting/en.json
+++ b/web/public/locales/i18n/reporting/en.json
@@ -26,6 +26,7 @@
   "statusSUPERSEDED": "Superseded",
   "carpPending": "Populated by CARP",
   "notApplicable": "NA",
+  "notSet": "-",
   "carpPopulatedHint": "This field is populated by the CARP and must be left empty on submission.",
   "notYetSubmitted": "Not Submitted",
 

--- a/web/src/Components/Reporting/reportingColumns.ts
+++ b/web/src/Components/Reporting/reportingColumns.ts
@@ -220,7 +220,17 @@ export const getAuthorizationsReportColumns = (t: Translate) => [
     col(t, "authorizedEntityIds", "aefT2AuthorizationsAuthoziedEntityId", "authorizedEntityIdsFootnote"),
   ]),
   col(t, "oimpAuthorized", "aefT2AuthorizationsOimpAuthorizedParty", "oimpAuthorizedFootnote"),
-  col(t, "authorizedTimeframe", "aefT2AuthorizationsAuthorizedTimeframe", "authorizedTimeframeFootnote"),
+  // Optional, and either year can be left blank — an unset timeframe reads as
+  // a dash rather than an empty cell, so it is visibly "not set" rather than
+  // looking like a rendering failure. A half-filled one shows the single year
+  // the backend stored.
+  emptyStateCol(
+    t,
+    "authorizedTimeframe",
+    "aefT2AuthorizationsAuthorizedTimeframe",
+    "notSet",
+    "authorizedTimeframeFootnote"
+  ),
   col(t, "authorizationTerms", "aefT2AuthorizationsAuthorizationTerms"),
   carpCol(t, "authorizationDocumentation", "aefT2AuthorizationsAuthorizationDocumentation"),
   col(


### PR DESCRIPTION
The Authorized timeframe could be stored as the literal "null - null": antd's InputNumber yields null for a cleared field rather than dropping the key, so the `!== undefined` guard let a cleared pair into the template literal. It is now emitted only when both years are present — a lone year would fail the `dddd - dddd` format at filing time, and the table renders unset as a dash.

Table 3's Action date reads as dd/mm/yyyy in the reporting tables, matching Table 2's. Query path only: the stored value and the CARP export keep the ISO datetime the spec requires. Formatted from the UTC instant, so a late-evening action does not display as the next day.