### PR TITLE
AEF V2: sort the reporting tables by a caller-supplied key

### DIFF
--- a/backend/services/libs/shared/src/aef-v2-registry/aef-v2-report.service.spec.ts
+++ b/backend/services/libs/shared/src/aef-v2-registry/aef-v2-report.service.spec.ts
@@ -80,3 +80,220 @@ describe("AefV2ReportService query display shaping", () => {
     expect(result.data).toEqual([]);
   });
 });
+
+/**
+ * `query`'s ordering. Applied in memory rather than through the store's own
+ * `sort`, because the same bundle feeds `download`/`submit` - see the service's
+ * `sorted` docblock.
+ */
+describe("AefV2ReportService query sorting", () => {
+  const defaults = {
+    aefT1SubmissionParty: "NGA",
+    aefT1SubmissionNdcFirstYear: 2021,
+    aefT1SubmissionNdcLastYear: 2030,
+  };
+
+  const buildService = (bundle: Record<string, unknown>) => {
+    const service = new AefV2ReportService(
+      {} as any, // storeFactory
+      defaults as any,
+      {} as any, // holdings
+      {} as any, // authorizedEntities
+      {} as any, // fileHandler
+      {} as any, // controlledValues
+      {} as any // countryService
+    );
+    (service as any).loadBundle = jest.fn().mockResolvedValue({
+      submission: undefined,
+      authorizations: [],
+      actions: [],
+      holdings: [],
+      authorizedEntities: [],
+      provisional: { holdings: false, authorizedEntities: false },
+      snapshotAt: { holdings: undefined, authorizedEntities: undefined },
+      ...bundle,
+    });
+    return service;
+  };
+
+  it("defaults to newest first by updatedAt when the caller sends no sort", async () => {
+    const service = buildService({
+      authorizations: [
+        { aefT2AuthorizationsId: "old", updatedAt: "2026-01-05T00:00:00.000Z" },
+        { aefT2AuthorizationsId: "new", updatedAt: "2026-08-11T00:00:00.000Z" },
+        { aefT2AuthorizationsId: "mid", updatedAt: "2026-04-02T00:00:00.000Z" },
+      ],
+    });
+
+    const result = await service.query("t2Authorizations", 2026);
+
+    expect(result.data.map((row: any) => row.aefT2AuthorizationsId)).toEqual(["new", "mid", "old"]);
+  });
+
+  /**
+   * The store hands back `Date` objects for the `timestamptz` metadata columns,
+   * not the ISO strings `AefRecordMeta` types them as. Stringifying a Date gives
+   * `"Sat Jan 03 2026 …"`, which collates by weekday name — so these two dates,
+   * three days apart in the same month, came back in the wrong order.
+   */
+  it("orders Date values chronologically, not by their stringified weekday", async () => {
+    const service = buildService({
+      authorizations: [
+        { aefT2AuthorizationsId: "sat-jan-03", updatedAt: new Date("2026-01-03T00:00:00.000Z") },
+        { aefT2AuthorizationsId: "mon-jan-05", updatedAt: new Date("2026-01-05T00:00:00.000Z") },
+      ],
+    });
+
+    const result = await service.query("t2Authorizations", 2026);
+
+    expect(result.data.map((row: any) => row.aefT2AuthorizationsId)).toEqual([
+      "mon-jan-05",
+      "sat-jan-03",
+    ]);
+  });
+
+  /**
+   * Timestamps compare as epoch, not as text, so precision cannot change the
+   * order: `…T00:00:00Z` collates *after* `…T00:00:00.500Z` under any string
+   * compare, because `.` precedes `Z`.
+   */
+  it("orders instants of differing precision chronologically", async () => {
+    const service = buildService({
+      authorizations: [
+        { aefT2AuthorizationsId: "earlier", updatedAt: "2026-01-05T00:00:00Z" },
+        { aefT2AuthorizationsId: "later", updatedAt: "2026-01-05T00:00:00.500Z" },
+      ],
+    });
+
+    const result = await service.query("t2Authorizations", 2026);
+
+    expect(result.data.map((row: any) => row.aefT2AuthorizationsId)).toEqual(["later", "earlier"]);
+  });
+
+  /**
+   * The two stores disagree on representation — TypeORM hands back `Date`, the
+   * in-memory one an ISO string. Both normalise to epoch, so a table sorts the
+   * same way whichever is behind it.
+   */
+  it("orders Date and ISO-string timestamps on the same scale", async () => {
+    const service = buildService({
+      authorizations: [
+        { aefT2AuthorizationsId: "iso-oldest", updatedAt: "2026-01-05T00:00:00.000Z" },
+        { aefT2AuthorizationsId: "date-newest", updatedAt: new Date("2026-08-11T00:00:00.000Z") },
+        { aefT2AuthorizationsId: "iso-middle", updatedAt: "2026-04-02T00:00:00.000Z" },
+      ],
+    });
+
+    const result = await service.query("t2Authorizations", 2026);
+
+    expect(result.data.map((row: any) => row.aefT2AuthorizationsId)).toEqual([
+      "date-newest",
+      "iso-middle",
+      "iso-oldest",
+    ]);
+  });
+
+  /**
+   * Only a full ISO instant is read as a timestamp. A string column must keep
+   * sorting as text, or a loose `Date.parse` would reorder it arbitrarily.
+   */
+  it("does not treat ordinary strings as timestamps", async () => {
+    const service = buildService({
+      authorizations: [
+        { aefT2AuthorizationsId: "CA0004-VU-CH-356" },
+        { aefT2AuthorizationsId: "CA0001-VU-CH-356" },
+        { aefT2AuthorizationsId: "CA0002-VU-CH-356" },
+      ],
+    });
+
+    const result = await service.query("t2Authorizations", 2026, {
+      key: "aefT2AuthorizationsId",
+      order: "ASC",
+    } as any);
+
+    expect(result.data.map((row: any) => row.aefT2AuthorizationsId)).toEqual([
+      "CA0001-VU-CH-356",
+      "CA0002-VU-CH-356",
+      "CA0004-VU-CH-356",
+    ]);
+  });
+
+  it("honours an explicit key and order from the request", async () => {
+    const service = buildService({
+      authorizations: [
+        { aefT2AuthorizationsId: "b", updatedAt: "2026-08-11T00:00:00.000Z" },
+        { aefT2AuthorizationsId: "a", updatedAt: "2026-01-05T00:00:00.000Z" },
+      ],
+    });
+
+    const result = await service.query("t2Authorizations", 2026, {
+      key: "aefT2AuthorizationsId",
+      order: "ASC",
+    } as any);
+
+    expect(result.data.map((row: any) => row.aefT2AuthorizationsId)).toEqual(["a", "b"]);
+  });
+
+  /**
+   * Table 3's Action date is rewritten to `dd/mm/yyyy` for display, which orders
+   * wrongly under a string compare - so the sort has to run on the stored ISO
+   * value, before that rewrite.
+   */
+  it("orders Table 3 by the stored instant, not the displayed dd/mm/yyyy", async () => {
+    const service = buildService({
+      actions: [
+        { aefT3ActionsType: "earlier", aefT3ActionsDate: "2026-02-28T00:00:00.000Z" },
+        { aefT3ActionsType: "later", aefT3ActionsDate: "2026-11-01T00:00:00.000Z" },
+      ],
+    });
+
+    const result = await service.query("t3Actions", 2026, {
+      key: "aefT3ActionsDate",
+      order: "DESC",
+    } as any);
+
+    expect(result.data.map((row: any) => row.aefT3ActionsType)).toEqual(["later", "earlier"]);
+    // Still displayed as the day alone.
+    expect(result.data[0]).toMatchObject({ aefT3ActionsDate: "01/11/2026" });
+  });
+
+  /**
+   * An open year's Holdings are computed live and never stored, so they carry no
+   * `updatedAt` to sort on. They must keep the provider's order rather than be
+   * shuffled into an arbitrary one.
+   */
+  it("leaves rows with no value for the sort key in their original order", async () => {
+    const service = buildService({
+      holdings: [
+        { aefT4HoldingsUnitRegistryId: "first" },
+        { aefT4HoldingsUnitRegistryId: "second" },
+        { aefT4HoldingsUnitRegistryId: "third" },
+      ],
+      provisional: { holdings: true, authorizedEntities: false },
+    });
+
+    const result = await service.query("t4Holdings", 2026);
+
+    expect(result.data.map((row: any) => row.aefT4HoldingsUnitRegistryId)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("puts rows missing the key last, after the ones that have it", async () => {
+    const service = buildService({
+      authorizations: [
+        { aefT2AuthorizationsId: "unstamped" },
+        { aefT2AuthorizationsId: "stamped", updatedAt: "2026-01-05T00:00:00.000Z" },
+      ],
+    });
+
+    const result = await service.query("t2Authorizations", 2026);
+
+    expect(result.data.map((row: any) => row.aefT2AuthorizationsId)).toEqual([
+      "stamped",
+      "unstamped",
+    ]);
+  });
+});

--- a/backend/services/libs/shared/src/aef-v2-registry/aef-v2-report.service.ts
+++ b/backend/services/libs/shared/src/aef-v2-registry/aef-v2-report.service.ts
@@ -27,6 +27,7 @@ import { Inject, Injectable } from "@nestjs/common";
 import * as fs from "fs";
 import * as path from "path";
 
+import { SortEntry } from "../dto/sort.entry";
 import { ExportFileType } from "../enum/export.file.type.enum";
 import { FileHandlerInterface } from "../file-handler/filehandler.interface";
 import { CountryService } from "../util/country.service";
@@ -41,6 +42,28 @@ import { RegistryControlledValueProvider } from "./providers/registry-controlled
 export interface AefV2DownloadResult {
   url: string;
   outputFileName: string;
+}
+
+/** Applied when the caller sends no `sort`. */
+const DEFAULT_SORT: SortEntry = { key: "updatedAt", order: "DESC" };
+
+/** A full ISO 8601 instant — excludes bare dates/years and anything else `Date.parse` would guess at. */
+const ISO_INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+// Timestamps compare as epoch, not as text: TypeORM returns `Date` objects
+// whose default stringification collates by weekday name, and ISO strings
+// only compare correctly when every value shares the same fractional precision.
+function comparable(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  if (typeof value === "string" && ISO_INSTANT.test(value)) {
+    const epoch = Date.parse(value);
+    if (!Number.isNaN(epoch)) {
+      return epoch;
+    }
+  }
+  return value;
 }
 
 /**
@@ -83,11 +106,12 @@ export class AefV2ReportService {
    * for Holdings/Authorized entities, the live-vs-frozen split itself. The
    * bundle already does all of that.
    */
-  async query(table: AefTableName, reportedYear: number) {
+  async query(table: AefTableName, reportedYear: number, sort: SortEntry = DEFAULT_SORT) {
     const bundle = await this.loadBundle(reportedYear);
     const exportData = toAefSubmissionExport(bundle);
     return {
-      data: this.forDisplay(table, exportData[table] ?? []),
+      // Sorted before forDisplay, which rewrites Table 3's date to dd/mm/yyyy.
+      data: this.forDisplay(table, this.sorted(exportData[table] ?? [], sort)),
       provisional:
         table === "t4Holdings"
           ? bundle.provisional.holdings
@@ -101,6 +125,39 @@ export class AefV2ReportService {
             ? bundle.snapshotAt.authorizedEntities
             : undefined,
     };
+  }
+
+  /**
+   * Ordering for the read path, in memory — not `AefQuery.sort` on the store,
+   * since `loadSubmissionBundle` also feeds `download`/`validate`/`submit`, and
+   * an open year's Tables 4/5 are provider-computed rows that never reach the
+   * store at all.
+   */
+  private sorted(rows: readonly Record<string, unknown>[], sort: SortEntry) {
+    if (!sort?.key) {
+      return rows;
+    }
+    const descending = String(sort.order ?? "DESC").toUpperCase() === "DESC";
+
+    // Partitioned rather than handled in the comparator, which must stay transitive.
+    const keyed: Record<string, unknown>[] = [];
+    const unkeyed: Record<string, unknown>[] = [];
+    for (const row of rows) {
+      const value = row[sort.key];
+      (value === undefined || value === null ? unkeyed : keyed).push(row);
+    }
+
+    keyed.sort((a, b) => {
+      const left = comparable(a[sort.key]);
+      const right = comparable(b[sort.key]);
+      const comparison =
+        typeof left === "number" && typeof right === "number"
+          ? left - right
+          : String(left).localeCompare(String(right));
+      return descending ? -comparison : comparison;
+    });
+
+    return sort.nullFirst ? [...unkeyed, ...keyed] : [...keyed, ...unkeyed];
   }
 
   /**

--- a/backend/services/libs/shared/src/aef-v2-registry/dto/aef.v2.query.dto.ts
+++ b/backend/services/libs/shared/src/aef-v2-registry/dto/aef.v2.query.dto.ts
@@ -1,6 +1,9 @@
 import { AEF_TABLE_NAMES, AefTableName } from "@app/aef-v2";
-import { ApiProperty } from "@nestjs/swagger";
-import { IsIn, IsInt, IsNotEmpty, IsPositive } from "class-validator";
+import { ApiProperty, ApiPropertyOptional, getSchemaPath } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { IsIn, IsInt, IsNotEmpty, IsOptional, IsPositive, ValidateNested } from "class-validator";
+
+import { SortEntry } from "../../dto/sort.entry";
 
 export class AefV2QueryDto {
   @ApiProperty({ enum: AEF_TABLE_NAMES })
@@ -12,4 +15,21 @@ export class AefV2QueryDto {
   @IsInt()
   @IsPositive()
   reportedYear: number;
+
+  /**
+   * Same shape the other tables' `queryExplorer` uses, so the frontend's sort
+   * handling is one pattern rather than two. Omitted means newest-first by
+   * `updatedAt` — see AefV2ReportService.DEFAULT_SORT.
+   */
+  @ApiPropertyOptional({
+    type: "object",
+    example: { key: "updatedAt", order: "DESC" },
+    items: {
+      $ref: getSchemaPath(SortEntry),
+    },
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SortEntry)
+  sort?: SortEntry;
 }

--- a/backend/services/src/national-api/aef-v2.controller.ts
+++ b/backend/services/src/national-api/aef-v2.controller.ts
@@ -30,7 +30,7 @@ export class AefV2Controller {
   @CheckPolicies((ability: AppAbility) => ability.can(Action.Read, AefReport))
   @Post("query")
   async query(@Body() dto: AefV2QueryDto): Promise<DataResponseDto> {
-    const result = await this.aefV2ReportService.query(dto.table, dto.reportedYear);
+    const result = await this.aefV2ReportService.query(dto.table, dto.reportedYear, dto.sort);
     return new DataResponseDto(HttpStatus.OK, result);
   }
 

--- a/web/src/Components/Reporting/ReportingComponent.tsx
+++ b/web/src/Components/Reporting/ReportingComponent.tsx
@@ -122,6 +122,8 @@ const ReportingComponent = (props: { translator: i18n }) => {
       const res = await post(API_PATHS.AEF_V2_QUERY, {
         table: AEF_V2_TABLE_NAME[type],
         reportedYear,
+        // Newest first.
+        sort: { key: "updatedAt", order: "DESC" },
       });
       const rows: Record<string, unknown>[] =
         res?.statusText === "SUCCESS" ? res.data?.data ?? [] : [];


### PR DESCRIPTION
The query endpoint returned rows in store order. It now takes an optional `sort` in the same `{ key, order }` shape as queryExplorer, defaulting to `updatedAt` DESC, applied in memory since the same bundle also feeds download/validate/submit.

Timestamps compare as epoch, not as text — TypeORM returns `Date` objects whose default stringification sorts by weekday name, and comparing ISO strings directly breaks once values differ in fractional precision.